### PR TITLE
Describe the planned Audit Process based on Pull Requests and Master-Commits

### DIFF
--- a/audit_method/src/01_change_tracking.rst
+++ b/audit_method/src/01_change_tracking.rst
@@ -125,9 +125,9 @@ Die Integrität des Repositories wird über den Commit SHA-1 Hash des
 Vorgängercommits sichergestellt. Da im Header des Vorgängercommits dessen
 Vorgängercommit SHA-1 Hash vorhanden ist kann die Kette bis zum initialen Commit
 gebildet und sichergestellt werden. Das heißt, dass die Veränderung eines
-Commits dazu führt das sich alle nachfolgenden Commit Hashes ändern und diese
-Veränderung erkannt wird. Um sicherzustellen das eine lokale Repository Kopie
-nicht verändert wurde muss daher der SHA-1 Hash des letzten bzw. aktuellsten
+Commits dazu führt, dass sich alle nachfolgenden Commit Hashes ändern und diese
+Veränderung erkannt wird. Um sicherzustellen, dass eine lokale Repository-Kopie
+nicht verändert wurde, muss daher der SHA-1 Hash des letzten bzw. aktuellsten
 Commits des lokalen Repositories mit dem entfernten Repository (bspw. auf
 GitHub) verglichen werden.
 

--- a/audit_method/src/01_change_tracking.rst
+++ b/audit_method/src/01_change_tracking.rst
@@ -1,19 +1,68 @@
 Verfolgen der Änderungen
 ========================
 
-Ziel der Änderungsverfolgung ist es, alle Änderungen an der Bibliothek zu
-identifizieren, nach ihrer Relevanz zu klassifizieren und relevante Änderungen
-genauer zu untersuchen. Dazu wird die Bibliothek zunächst in Komponenten
-aufgeteilt. Zu den Komponenten gehören die Module der Bibliothek selbst
-(Verzeichnis src/lib), die Testsuite (Verzeichnis src/tests), das Command Line
-Interface (Verzeichnis src/cli), der Python-Wrapper (Verzeichnis src/python),
-das Buildsystem (Skript configure.py und Verzeichnis src/build-data) sowie die
-Dokumentation (Verzeichnis doc). Für jede dieser Komponenten wird ein
-textbasiertes Diff erstellt. Zur Erzeugung des Diffs kommt das Linux
-Kommandozeilentool *diff* zum Einsatz. Jedes Diff wird analysiert und die darin
-enthaltenen Änderungen werden für jede der Komponenten dokumentiert. Jede
-Änderung wird dabei klassifiziert, d.h., einer Kategorie zugeordnet, die die
-Relevanz der Änderung für die Sicherheit der gesamten Bibliothek anzeigt.
+Einsatz von Git und GitHub bei der Entwicklung der Bibliothek
+-------------------------------------------------------------
+
+Die Bibliothek wird öffentlich auf GitHub [#botangithub]_ entwickelt. Größere
+Änderungen am Code werden in der Regel über themenspezifische "Pull Requests"
+[#botanpulls]_ nach einem technischen Review-Prozess durch einen der
+Kern-Entwickler der Bibliothek (GitHub "Collaborator") vorgenommen. In
+Ausnahmefällen pflegt der Hauptentwickler (Jack Lloyd) kleinere Änderungen
+direkt in den Entwicklungszweig der Bibliothek ein. Insbesondere diese direkten
+Änderungen sind stets vom Hauptentwickler mittels GPG signiert [#jackgpg]_.
+
+In beiden Fällen erlauben die "Pull Requests" und die direkten Änderungen eine
+transparente und verhältnismäßig leicht nach Themen klassifizierbare
+Nachverfolgung aller Änderungen in der Bibliothek. Im Folgenden bezieht sich der
+Begriff "Patch" sowohl auf Änderungen die mittels eines Pull Requests
+eingeflossen sind als auch auf direkte Änderungen durch den Hauptentwickler.
+
+Das Datenmodell von "Git" stellt dabei sicher, dass die Anwendung aller Patches
+zwischen zwei Quelltext-Versionen eindeutig von der älteren zur neueren Version
+führt. Damit sind alle tatsächlichen Änderungen zwischen zwei Versionen mit der
+Gesamtheit aller Patches abgebildet, die von der älteren zur neueren Version
+geführt haben.
+
+Dieser Auditierungs-Ansatz setzt die Vertrauenswürdigkeit von "Git" und dessen
+Datenmodell voraus. Am Ende dieses Kapitels findet sich daher eine kurze
+Erläuterung zur Vertrauenswürdigkeit von Git (siehe :ref:`about_git`).
+
+.. [#botangithub] `github.com/randombit/botan <https://github.com/randombit/botan>`_
+.. [#botanpulls] `github.com/randombit/botan/pulls <https://github.com/randombit/botan/pulls>`_
+.. [#jackgpg] GPG Schlüssel ID von Jack Lloyd: ``9F:FD:59:6F:AB:50:F9:0D``
+
+Nachträgliche Änderungsverfolgung
+---------------------------------
+
+Die Bibliothek wurde für einzelne Versionen bereits in der Vergangenheit einem
+Audit unterzogen. Ziel der Änderungsverfolgung ist es, alle Änderungen an der
+Bibliothek zu identifizieren die seit dem letzten Audit hinzugekommen sind,
+diese nach ihrer Relevanz zu klassifizieren und relevante Änderungen genauer zu
+untersuchen.
+
+Dazu werden wie oben beschrieben mithilfe von "Git" alle Patches der Bibliothek
+identifiziert, die von einer bereits auditierten Version zur neuen Zielversion
+geführt haben. Einzelne Patches haben dabei meist einen thematischen Bezug und
+eine technische Beschreibung ("Commit" Nachricht oder "Pull Request"
+Beschreibung). Beispielsweise: "Add XMSS Parameter sets defined in NIST
+SP.800-208" [#xmssparams]_ enthält die Quelltext-Änderungen um die XMSS
+Implementierung um die vom NIST spezifizierten Parameter zu erweitern.
+
+Jeder Patch kann dabei prinzipiell beliebige Komponenten der Bibliothek
+betreffen. Die hier betrachteten Komponenten sind die Bibliothek selbst
+(Verzeichnis *src/lib*), die Testsuite (Verzeichnis *src/tests*), das Command Line
+Interface (Verzeichnis *src/cli*), der Python-Wrapper (Verzeichnis *src/python*),
+das Buildsystem (Skript *configure.py* und Verzeichnis *src/build-data*) sowie die
+Dokumentation (Verzeichnis *doc*).
+
+Alle Patches werden nun manuell thematisch vorsortiert und danach einzeln
+analysiert, nach Sicherheitsrelevanz klassifiziert und die enthaltenen
+Änderungen dokumentiert. Das Ergebnis ist ein detailierter themenbezogener
+Änderungsbericht mit Referenzen zu allen relevanten Patches. Eine spätere
+Nachvollziehbarkeit (etwa durch Dritte) ist damit leicht zu gewährleisten.
+
+.. [#xmssparams] GitHub Pull Request: `#3292 <https://github.com/randombit/botan/pull/3292>`_
 
 Klassifizierung
 ---------------
@@ -38,12 +87,25 @@ kryptographischen Funktionen erhöhen. Änderungen der Kategorie III bezeichnen
 weitere, nicht-sicherheitskritische Änderungen, d.h., Änderungen aus anderen
 Gründen als bezogen auf die Sicherheit.
 
-Zur Herstellung des Kontextes oder der Absicht einer Änderung, oder zur
-Identifizierung einer Änderung als gleichzeitige Änderung an mehreren,
-miteinander verbundenen Modulen, kann es notwendig sein den Git Commit, dem die
-Änderung zugrunde liegt, zu identifizieren und das Diff des jeweiligen Commits
-anzusehen. Nachfolgend findet sich daher eine kurze Erläuterung zur
-Vertrauenswürdigkeit von Git.
+Thematische Einordnung
+----------------------
+
+Zur besseren Übersicht und zur Vereinfachung des Audit-Prozesses werden Patches
+soweit möglich thematisch sortiert. Dabei besteht ausdrücklich keine
+eins-zu-eins Beziehung von Patches und Themen. Ein Patch kann durchaus Relevanz
+für mehr als ein betrachtetes Thema haben und damit mehrmals zugeordnet werden.
+
+Denkbare Themen sind etwa "Hinzufügen einer Implementierung von CRYSTALS-Kyber",
+"Schließen einer Sicherheitslücke in der Validierung von X.509 Zertifikaten"
+oder "Beschleunigung der Continuous Integration Pipeline". Für jedes Thema
+werden die relevanten Patches aufgezählt und die enthaltenen Änderungen
+übergreifend dokumentiert.
+
+Themen können ebenfalls eine Klassifizierung der Sicherheitsrelevanz erhalten.
+Danach richtet sich gegebenenfalls die Betrachtungstiefe der Patches im Kontext
+des Themas.
+
+.. _about_git:
 
 Sicherheit und Vertrauenswürdigkeit von Git
 -------------------------------------------

--- a/audit_method/src/01_change_tracking.rst
+++ b/audit_method/src/01_change_tracking.rst
@@ -56,8 +56,8 @@ Interface (Verzeichnis *src/cli*), der Python-Wrapper (Verzeichnis *src/python*)
 das Buildsystem (Skript *configure.py* und Verzeichnis *src/build-data*) sowie die
 Dokumentation (Verzeichnis *doc*).
 
-Alle Patches werden nun manuell thematisch vorsortiert und danach einzeln
-analysiert, nach Sicherheitsrelevanz klassifiziert und die enthaltenen
+Alle identifizierten Patches werden manuell thematisch vorsortiert und danach
+einzeln analysiert, nach Sicherheitsrelevanz klassifiziert und die enthaltenen
 Änderungen dokumentiert. Das Ergebnis ist ein detailierter themenbezogener
 Änderungsbericht mit Referenzen zu allen relevanten Patches. Eine spätere
 Nachvollziehbarkeit (etwa durch Dritte) ist damit leicht zu gewährleisten.
@@ -131,15 +131,15 @@ nicht verändert wurde, muss daher der SHA-1 Hash des letzten bzw. aktuellsten
 Commits des lokalen Repositories mit dem entfernten Repository (bspw. auf
 GitHub) verglichen werden.
 
-Git ist also inherent von der Kollisionsresistenz in SHA-1 abhängig. Andernfalls
-könnten Commit-Paare mit gleichem SHA-1 Hash verwendet werden um Schadcode
-unbemerkt vom oben beschriebenen Audit Prozess in ein Repository einzuschleusen.
-Ein Angreifer müsste dafür ein Paar von validen Git Commit Objekten mit
-einerseits harmlosen (aber funktionsfähigen) Änderungen und andererseits einem
-Schadcode erzeugen. Eine 2017 von Stevens et al. veröffentlichte Schwachstelle
-in SHA-1 [SHATRD]_ ermöglicht dies zwar theoretisch; es ist uns zum aktuellen
-Zeitpunkt aber kein Beispiel bekannt, wo dies erfolgreich für Git Commit Objekte
-demonstriert wurde.
+Git ist also inhärent von der Kollisionsresistenz in SHA-1 abhängig. Durch eine
+Hash-Kollision könnten Commit-Paare mit gleichem SHA-1 Hash verwendet werden, um
+Schadcode unbemerkt vom oben beschriebenen Audit-Prozess in ein Repository
+einzuschleusen. Ein Angreifer müsste dafür ein Paar von validen Git Commit
+Objekten mit einerseits harmlosen (aber funktionsfähigen) Änderungen und
+andererseits einem Schadcode erzeugen, die denselben Commit Hash besitzen. Eine
+2017 von Stevens et al. veröffentlichte Schwachstelle in SHA-1 [SHATRD]_
+ermöglicht dies zwar theoretisch; es ist uns zum aktuellen Zeitpunkt aber kein
+Beispiel bekannt, wo dies erfolgreich für Git Commit Objekte demonstriert wurde.
 
 Dabei ist es wichtig zu wissen, dass für eine erfolgreiche Kollision beide
 Commits (der Harmlose wie auch der Manipulierte) vom Angreifer erzeugt werden
@@ -147,7 +147,7 @@ müssten. Es ist also ausdrücklich *nicht* möglich einen existierenden legitim
 Commit des Repositorys nachträglich auszutauschen. Der Angreifer müsste den
 harmlosen Commit also schon frühzeitig in Botan einschleusen.
 
-Mittels Counter-Cryptoanalyse lassen sich Objekte die Teil eines solchen
+Mittels Counter-Kryptoanalyse lassen sich Objekte die Teil eines solchen
 Angriffs sind aber sicher erkennen (siehe SHA-1-DC [SHA1DC]_). Seit
 Bekanntwerden der Schwachstelle verwenden sowohl GitHub [#githubsha1]_ als auch
 Git [#gitsha1]_ SHA-1-DC und lehnen Objekte ab die Teil einer so erzeugten
@@ -159,7 +159,7 @@ Hashfunktion angestrebt werden. Dies liegt aber mangels Unterstützung der Git
 Hosting-Provider (wie etwa GitHub) [#lwngitsha1]_ nicht in der Hand der
 Botan-Entwickler oder den Auditoren in diesem Projekt. Durch die wirksamen
 Gegenmaßnahmen mittels SHA-1-DC ist es zum gegebenen Zeitpunkt aber vertretbar
-Git für den beschriebenen Audit Prozess zu vertrauen.
+Git für den beschriebenen Audit-Prozess zu vertrauen.
 
 Weiterhin bietet Git die Möglichkeit einzelne Commits mittels GPG zu signieren.
 Auf diese Weise wird die Authentizität der Commits sichergestellt. Die Botan

--- a/audit_method/src/01_change_tracking.rst
+++ b/audit_method/src/01_change_tracking.rst
@@ -165,6 +165,10 @@ Weiterhin bietet Git die Möglichkeit einzelne Commits mittels GPG zu signieren.
 Auf diese Weise wird die Authentizität der Commits sichergestellt. Die Botan
 Entwickler machen von dieser Möglichkeit weitestgehend Gebrauch.
 
+Teil :ref:`des Abgabe-Paketes <deliverables>` jedes Audits ist ein signiertes
+Quellcode-Archiv der auditierten Bibliotheksversion. Nutzer der Bibliothek haben
+somit auch ohne die Verwendung von Git Zugriff auf den gesamten Quellcode.
+
 .. [#githubsha1] `github.blog/2017-03-20-sha-1-collision-detection-on-github-com <https://github.blog/2017-03-20-sha-1-collision-detection-on-github-com>`_
 .. [#gitsha1] `github.blog/2017-05-10-git-2-13-has-been-released <https://github.blog/2017-05-10-git-2-13-has-been-released/#sha-1-collision-detection>`_
 .. [#lwngitsha1] `lwn.net/Articles/898522 <https://lwn.net/Articles/898522>`_

--- a/audit_method/src/06_summary.rst
+++ b/audit_method/src/06_summary.rst
@@ -1,3 +1,5 @@
+.. _deliverables:
+
 Zusammenfassung und Ergebnisse
 ==============================
 

--- a/audit_method/src/90_references.rst
+++ b/audit_method/src/90_references.rst
@@ -22,6 +22,18 @@
    "Pflege und Weiterentwicklung der Kryptobibliothek Botan (Weiterentwicklung Botan): Cryptogrphic Documentation"
    Version 1.5.0, 03.11.2022.
 
+.. [SHATRD]
+   Stevens, M., Bursztein, E., Karpman, P., Albertini, A., Markov, Y. (2017).
+   The First Collision for Full SHA-1. In: Katz, J., Shacham, H. (eds) Advances
+   in Cryptology - CRYPTO 2017. CRYPTO 2017. Lecture Notes in Computer
+   Science(), vol 10401. Springer, Cham.
+   https://doi.org/10.1007/978-3-319-63688-7_19
+
+.. [SHA1DC]
+   Counter-cryptanalysis, Marc Stevens, CRYPTO 2013, Lecture Notes in Computer
+   Science, vol. 8042, Springer, 2013, pp. 129-146,
+   https://marc-stevens.nl/research/papers/C13-S.pdf
+
 .. [CPPCHECK]
    `http://cppcheck.sourceforge.net <http://cppcheck.sourceforge.net/>`_
 


### PR DESCRIPTION
That's the process document description to the suggested audit process change we discussed in the Jour Fixe on Feb 22nd 2023. Along with it comes a more detailed write-up of why SHA-1 as used in Git is still considered trustworthy, despite [the "SHAttered" attack](https://shattered.io/) by Stevens et al.