### PR TITLE
Add SPHINCS+ Documentation

### DIFF
--- a/cryptodoc/src/06_pubkey_key_generation.rst
+++ b/cryptodoc/src/06_pubkey_key_generation.rst
@@ -481,10 +481,11 @@ SPHINCS\ :sup:`+`
 -----------------
 
 Botan's SPHINCS\ :sup:`+` implementation is found in
-:srcref:`src/lib/pubkey/sphincsplus/` and follows [SPX-R3]_. It supports the
-parameter sets provided in Table 3 of [SPX-R3]_ for the SHA2 and SHAKE
-instantiations of hash functions (note that currently, the instantiations with
-Haraka are not supported). An overview is provided in Table :ref:`Supported
+:srcref:`src/lib/pubkey/sphincsplus/` and follows [SPX-R3]_.
+Only the "simple" version of the scheme is available.
+Botan supports the parameter sets provided in Table 3 of [SPX-R3]_ for the SHA2
+and SHAKE instantiations of hash functions (note that currently, the instantiations
+with Haraka are not supported). An overview is provided in Table :ref:`Supported
 SPHINCS+ parameter sets <pubkey_key_generation/sphincsplus/params_table>`.
 
 .. _pubkey_key_generation/sphincsplus/params_table:
@@ -509,7 +510,7 @@ SPHINCS+ parameter sets <pubkey_key_generation/sphincsplus/params_table>`.
 
 SPHINCS\ :sup:`+` key generation follows Section 6.2 of [SPX-R3]_ and is
 implemented in :srcref:`src/lib/pubkey/sphincsplus/sphincspluscommon/sphincsplus.cpp`
-within the the ``SphincsPlus_PrivateKey`` constructor. It works as follows:
+within the ``SphincsPlus_PrivateKey`` constructor. It works as follows:
 
 .. admonition:: SPHINCS+ Key Generation
 
@@ -519,7 +520,7 @@ within the the ``SphincsPlus_PrivateKey`` constructor. It works as follows:
 
    **Output:**
 
-   -  ``SK``, ``PK``: private and public keys
+   -  ``SK``, ``PK``: private and public key
 
    **Steps:**
 

--- a/cryptodoc/src/06_pubkey_key_generation.rst
+++ b/cryptodoc/src/06_pubkey_key_generation.rst
@@ -257,6 +257,8 @@ it is not expected that this restriction affects the security of the resulting R
 [TR-02102-1]_. The minimum possible bit length of the modulus N should be
 increased to the recommendation of 2000 bit.
 
+.. _pubkey_key_generation/xmss:
+
 XMSS with WOTS+
 ---------------
 
@@ -472,6 +474,66 @@ in constant time on identical hardware if the hash function computations
 run in constant time. Therefore, an attacker can infer the position in
 the tree that the algorithm is currently working on even if only a
 single thread is used.
+
+.. _pubkey_key_generation/sphincsplus:
+
+SPHINCS\ :sup:`+`
+-----------------
+
+Botan's SPHINCS\ :sup:`+` implementation is found in
+:srcref:`src/lib/pubkey/sphincsplus/` and follows [SPX-R3]_. It supports the
+parameter sets provided in Table 3 of [SPX-R3]_ for the SHA2 and SHAKE
+instantiations of hash functions (note that currently, the instantiations with
+Haraka are not supported). An overview is provided in Table :ref:`Supported
+SPHINCS+ parameter sets <pubkey_key_generation/sphincsplus/params_table>`.
+
+.. _pubkey_key_generation/sphincsplus/params_table:
+
+.. table::  Supported SPHINCS+ parameter sets (see Table 3 of [SPX-R3]_). <hash> can either be ``sha2`` or ``shake``.
+
+   +----------------------------------+-------------+-------------+-----------+-----------------+-----------+-----------+
+   | Parameter Set                    |  :math:`n`  |  :math:`h`  | :math:`d` | :math:`log(t)`  | :math:`k` | :math:`w` |
+   +==================================+=============+=============+===========+=================+===========+===========+
+   | ``SphincsPlus-<hash>-128s-r3.1`` | 16          | 63          | 7         | 12              | 14        | 16        |
+   +----------------------------------+-------------+-------------+-----------+-----------------+-----------+-----------+
+   | ``SphincsPlus-<hash>-128f-r3.1`` | 16          | 66          | 22        |  6              | 33        | 16        |
+   +----------------------------------+-------------+-------------+-----------+-----------------+-----------+-----------+
+   | ``SphincsPlus-<hash>-192s-r3.1`` | 24          | 63          | 7         | 14              | 17        | 16        |
+   +----------------------------------+-------------+-------------+-----------+-----------------+-----------+-----------+
+   | ``SphincsPlus-<hash>-192f-r3.1`` | 24          | 66          | 22        |  8              | 33        | 16        |
+   +----------------------------------+-------------+-------------+-----------+-----------------+-----------+-----------+
+   | ``SphincsPlus-<hash>-256s-r3.1`` | 32          | 64          | 8         | 14              | 22        | 16        |
+   +----------------------------------+-------------+-------------+-----------+-----------------+-----------+-----------+
+   | ``SphincsPlus-<hash>-256f-r3.1`` | 32          | 68          | 17        |  9              | 35        | 16        |
+   +----------------------------------+-------------+-------------+-----------+-----------------+-----------+-----------+
+
+SPHINCS\ :sup:`+` key generation follows Section 6.2 of [SPX-R3]_ and is
+implemented in :srcref:`src/lib/pubkey/sphincsplus/sphincspluscommon/sphincsplus.cpp`
+within the the ``SphincsPlus_PrivateKey`` constructor. It works as follows:
+
+.. admonition:: SPHINCS+ Key Generation
+
+   **Input:**
+
+   -  ``rng``: random number generator
+
+   **Output:**
+
+   -  ``SK``, ``PK``: private and public keys
+
+   **Steps:**
+
+   1. Generate new values ``secret_seed``, ``prf``, and ``public_seed`` using ``rng``.
+   2. ``sphincs_root = xmss_gen_root(secret_seed)``
+      (see :ref:`SPHINCS+ XMSS <signatures/sphincsplus/XMSS>`).
+   3. | ``SK = {secret_seed, prf, public_seed, sphincs_root}``
+      | ``PK = {public_seed, sphincs_root}``
+
+   **Notes:**
+
+   - The creation of a public key is conducted using the
+     ``public_key`` method of the private key.
+
 
 .. _pubkey_key_generation/dilithium:
 

--- a/cryptodoc/src/06_pubkey_key_generation.rst
+++ b/cryptodoc/src/06_pubkey_key_generation.rst
@@ -509,7 +509,7 @@ SPHINCS+ parameter sets <pubkey_key_generation/sphincsplus/params_table>`.
    +----------------------------------+-------------+-------------+-----------+-----------------+-----------+-----------+
 
 SPHINCS\ :sup:`+` key generation follows Section 6.2 of [SPX-R3]_ and is
-implemented in :srcref:`src/lib/pubkey/sphincsplus/sphincspluscommon/sphincsplus.cpp`
+implemented in :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.cpp`
 within the ``SphincsPlus_PrivateKey`` constructor. It works as follows:
 
 .. admonition:: SPHINCS+ Key Generation

--- a/cryptodoc/src/08_signatures.rst
+++ b/cryptodoc/src/08_signatures.rst
@@ -460,6 +460,8 @@ The signature verification algorithm works as follows:
       :math:`W = {{v_{1} \ast G} + {v_{2} \ast Q}}`
    5. Return ``true`` if :math:`r \equiv x_1 \bmod q` applies. Otherwise it returns ``false``.
 
+.. _signatures/xmss:
+
 XMSS with WOTS+
 ---------------
 
@@ -860,3 +862,316 @@ Hence, the special case occurs (L.21-22, Figure 3 of [Dilithium-R3]_) and we get
 
 Taking into account these cases where the hint becomes :math:`0`, Botan only checks the :math:`\gamma_2` bounds of coefficients :math:`x` of the input vector :math:`(\mathbf{w_0} - c \mathbf{s_2} + c\mathbf{t_0})`.
 To distinguish both cases with slightly different boundaries, :math:`\mathbf{w_1}` must be given as well.
+
+SPHINCS\ :sup:`+`
+-----------------
+
+SPHINCS\ :sup:`+` is composed of Forest Of Random Subset (FORS) signatures and
+Winternitz One-Time Signatures (WOTS\ :sup:`+`), which are used
+within hypertree signatures (a variant of XMSS\ :sup:`MT`). In short, messages
+are signed via FORS. The FORS public key is signed via XMSS with WOTS\ :sup:`+`
+as part of the hypertree and the overall root represents the SPHINCS\ :sup:`+`
+root. Table :ref:`SPHINCS+ logical components <signatures/sphincsplus/table>`
+provides an overview of these components and their Botan implementations. The
+:ref:`SPHINCS+ <signatures/sphincsplus/sphincsplus>` component, by making use of
+the other components, provides the overall signature generation and verification
+operations.
+
+.. _signatures/sphincsplus/table:
+
+.. table::  SPHINCS\ :sup:`+` logical components and file locations.
+
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   |  Component                                           | File                                                                    | Purpose                                    | Section in [SPX-R3]_         |
+   +======================================================+=========================================================================+============================================+==============================+
+   | :ref:`Types <signatures/sphincsplus/types>`          | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_types.h`      | Strong types                               |                              |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`Address <signatures/sphincsplus/address>`      | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_address.h`    | Address representation and manipulation    | 2.7.3                        |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`Parameters <signatures/sphincsplus/parameters>`| :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_parameters.h` | Parameter set instantiations               | 7.1                          |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`Hashes <signatures/sphincsplus/hashes>`        | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hash.h`       | All hash functions                         | 7.2                          |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`Treehash <signatures/sphincsplus/treehash>`    | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_treehash.h`   | Merkle tree hashing for FORS and hypertree | 4.1.3, 5.3                   |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`FORS <signatures/sphincsplus/fors>`            | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_fors.h`       | FORS signature                             | 5                            |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`WOTS+ <signatures/sphincsplus/wotsplus>`       | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_wots.h`       | WOTS\ :sup:`+` signature                   | 3                            |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`XMSS <signatures/sphincsplus/xmss>`            | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_xmss.h`       |     XMSS    signature                      | 4.1                          |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`Hypertree <signatures/sphincsplus/hypertree>`  | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hypertree.h`  | Hypertree signature                        | 4.2                          |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+   | :ref:`SPHINCS+ <signatures/sphincsplus/sphincsplus>` | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.h`   | SPHINCS\ :sup:`+` signature                | 6                            |
+   +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
+
+.. _signatures/sphincsplus/types:
+
+Types
+^^^^^
+
+In Botan's SPHINCS\ :sup:`+` implementation, the concept of strong types is
+used. A strong type can be used to create unique C++ types for data that is
+semantically different, but operates on the same internal data structures.
+SPHINCS\ :sup:`+` mainly operates on byte vectors in various contexts (e.g.,
+XMSS tree nodes, WOTS\ :sup:`+` chain node, public/secret seeds, etc.), as well
+as combined contexts like a WOTS\ :sup:`+` signature composed of multiple
+WOTS\ :sup:`+` nodes. In SPHINCS\ :sup:`+`, every context is represented by a
+separate strong type. The NIST status report [IR-8413]_ in Section 4.4.3 notes
+that SPHINCS\ :sup:`+` must be implemented with caution due to its complex
+nature. The usage of strong types creates a much clearer and more
+self-documenting interface, which also guarantees that no data is misused in the
+wrong context. More details on all defined strong types and their interpretation
+are documented in the respective header file.
+
+.. _signatures/sphincsplus/address:
+
+Address
+^^^^^^^
+
+Botan's SPHINCS\ :sup:`+` addresses wrap the address specification of [SPX-R3]_
+into a class ``Sphincs_Address``. Methods for getting, copying, and setting
+specified fields of an address are provided as well as constants. All constants,
+fields, and representations are set as specified in Section 2.7.3 of [SPX-R3]_.
+
+.. _signatures/sphincsplus/parameters:
+
+Parameters
+^^^^^^^^^^
+
+The class ``Sphincs_Parameters`` represents all parameters of SPHINCS\ :sup:`+`.
+It checks whether provided parameters are valid and can be created from a given
+``Sphincs_Parameter_Set``, representing each set of Table :ref:`Supported
+SPHINCS+ parameter sets <pubkey_key_generation/sphincsplus/params_table>`.
+Parameters that can be computed directly from the parameter set are calculated
+in the constructor and stored as members instead of being calculated on demand.
+
+.. _signatures/sphincsplus/hashes:
+
+Hashes
+^^^^^^
+
+Botan implements the SHA2 and SHAKE versions of SPHINCS\ :sup:`+` as different
+modules. All hash functions used within SPHINCS\ :sup:`+` are represented by the
+class ``Sphincs_Hash_Functions``, which can be instantiated from given
+parameters and the public seed ``pub_seed``. The public seed is given at
+creation because all calls to the ``T`` and ``PRF`` functions use the public
+seed as input. All underlying hash function members are instantiated in the
+constructor according to Section 7.2 of [SPX-R3]_. The specific child classes
+for the SHA2 and SHAKE modules are given in
+:srcref:`src/lib/pubkey/sphincsplus/sphincsplus_sha2/sp_hash_sha2.h` and
+:srcref:`src/lib/pubkey/sphincsplus/sphincsplus_shake/sp_hash_shake.h`,
+respectively.
+
+The specification defines three tweaked hash functions that share similarities.
+:math:`\mathbf{T_\ell}` is a tweaked hash function with a message input length
+of :math:`\ell n` bytes. :math:`\mathbf{F}` and :math:`\mathbf{H}` are simply
+defined as :math:`\mathbf{T_1}` and :math:`\mathbf{T_2}`, for consistency with
+other hash-based signature schemes (Section 2.7.1 of [SPX-R3]_). For clarity and
+convenience, Botan omits the additional definitions by only implementing and
+calling the method ``T``, which allows for arbitrary input lengths.
+
+.. _signatures/sphincsplus/treehash:
+
+Treehash
+^^^^^^^^
+
+Botan generalizes the treehash Algorithms 7  (:math:`\mathtt{treehash}`) and 15
+(:math:`\mathtt{fors\_treehash}`) of [SPX-R3]_ using a single function
+``treehash``,  similar to SPHINCS\ :sup:`+`'s reference implementation. This
+approach minimizes duplicate code while explicitly being in accordance with the
+specification (see Section 5.3 of [SPX-R3]_). The only difference between the
+treehash of FORS and XMSS is the creation of leaf nodes. Therefore, ``treehash``
+takes a callback function for the leaf creation logic as an additional argument.
+This callback function also handles the hash function addresses according to its
+purpose. The used callback functions are ``xmss_gen_leaf`` (for XMSS; see
+:ref:`SPHINCS+ XMSS <signatures/sphincsplus/xmss>`) and ``fors_gen_leaf``
+(for FORS; see :ref:`SPHINCS+ FORS <signatures/sphincsplus/fors>`).
+
+Another generalization of the specification that is also adapted from the
+reference implementation is the integration of authentication path computations
+into the ``treehash`` function. To achieve this, the function also takes the
+index of the leaf for which to compute the authentication path. When building up
+the Merkle tree, the function adds currently computed nodes to the
+authentication path if they are contained in it. Alternatively, if only the root
+node is requested (i.e. when computing :math:`\mathbf{PK}.\mathsf{root}`), the
+leaf index can be set to an empty value, in which case no authentication path is
+computed.
+
+Furthermore, the same generalization ideas are applied to the root computation
+from a signature, i.e., Algorithms 10 (:math:`\mathtt{xmss\_pkFromSig}`) and 18
+(:math:`\mathtt{fors\_pkFromSig}`) of [SPX-R3]_. Botan's function
+``compute_root`` computes the root of a Merkle tree using a leaf and its
+authentication path. For both XMSS and FORS, the logic is the same, with the
+only condition being that correctly preconfigured hash function addresses must
+be passed to the function.
+
+.. _signatures/sphincsplus/fors:
+
+FORS
+^^^^
+
+Although FORS is a stand-alone few-time signature scheme, only methods relevant
+to its overall use in SPHINCS\ :sup:`+` are implemented in Botan. This is
+:math:`\mathtt{fors\_sign}` of [SPX-R3]_ (Section 5.5) and
+:math:`\mathtt{fors\_pkFromSig}` of [SPX-R3]_ (Section 5.6). More concretely,
+both methods are combined into Botan's ``fors_sign_and_pkgen``, which computes
+both the signature and the FORS public key. The authentication path computation
+therein and :math:`\mathtt{fors\_treehash}` of [SPX-R3]_ (Section 5.3) are
+implemented in the generalized ``treehash`` (see
+:ref:`SPHINCS+ Treehash <signatures/sphincsplus/treehash>`), whereby
+:math:`\mathtt{fors\_SKgen}` of [SPX-R3]_ (Section 5.2) is implemented within
+the callback function ``fors_gen_leaf`` supplied to ``treehash``.
+Similarly, the computation of the root and authentication path in the
+implementation of :math:`\mathtt{fors\_pkFromSig}` utilizes the generalized
+``compute_root`` method (see :ref:`SPHINCS+ Treehash
+<signatures/sphincsplus/treehash>`), resulting in the method
+``fors_public_key_from_signature``.
+
+.. _signatures/sphincsplus/wotsplus:
+
+WOTS\ :sup:`+`
+^^^^^^^^^^^^^^
+
+The implementation of WOTS\ :sup:`+` in the context of SPHINCS\ :sup:`+` is
+based on [SPX-R3]_ with some adaptions of the SPHINCS\ :sup:`+` reference
+implementations. In the same manner as FORS, it utilizes a generalization that
+fuses the WOTS\ :sup:`+` public key and signature creation, i.e., the algorithms
+:math:`\mathtt{wots\_PKgen}` and :math:`\mathtt{wots\_sign}` of [SPX-R3]_, into
+one method. When building up an XMSS tree, all leaf nodes must be computed,
+which are the hashed WOTS\ :sup:`+` public keys. Only one leaf is used to sign
+the underlying root. The WOTS\ :sup:`+` signature consists of values that are
+computed in every public key creation; these values are part of the
+WOTS\ :sup:`+` hash chains. This observation leads to Botan's
+``wots_sign_and_pkgen`` method that combines both logics, i.e., the entire
+WOTS\ :sup:`+` chains are computed for the public key while the WOTS\ :sup:`+`
+signature values are extracted at the same time if the current leaf is the
+signing one.
+
+.. _signatures/sphincsplus/XMSS:
+
+XMSS
+^^^^
+
+**Remark:** Botan's implementation of the XMSS logic of SPHINCS\ :sup:`+` is
+specifically tailored to SPHINCS\ :sup:`+` and separate from Botan's standalone
+XMSS implementation (see :ref:`XMSS Key Generation <pubkey_key_generation/xmss>`
+and :ref:`XMSS Signatures <signatures/xmss>`). This is due to the differences in
+their tweaked hash applications, including a different hash function addressing.
+
+To create a single XMSS signature, the building blocks of the preceding sections
+are composed into the function ``xmss_sign_and_pkgen``. The generic ``treehash``
+function (see :ref:`SPHINCS+ Treehash <signatures/sphincsplus/treehash>`) is the
+core logic of XMSS. For generating leaves, it uses the provided callback function
+``xmss_gen_leaf``, which calls ``wots_sign_and_pkgen`` (see :ref:`SPHINCS+ WOTS+
+<signatures/sphincsplus/wotsplus>`) since XMSS leaves are hashed WOTS\ :sup:`+`
+public keys. This callback function contains all necessary parameters including
+the index of the leaf to sign, the message to sign (already divided into
+:math:`log(w)` sized chunks), and the required hash function addresses.
+
+While ``xmss_gen_leaf`` creates and stores the neccessary WOTS\ :sup:`+`
+signature, ``treehash`` adds the authentication path to the XMSS signature when
+building up the XMSS Merkle tree. Therefore, ``xmss_sign_and_pkgen`` creates its
+XMSS root node and signature for a given leaf index and message and covers both
+Algorithm 8 (:math:`\mathtt{xmss\_PKgen}`) and Algorithm 9
+(:math:`\mathtt{xmss\_sign}`) of [SPX-R3]_.
+
+For public key creation, i.e., the creation of :math:`\mathbf{PK}.\mathsf{root}`,
+the function ``xmss_gen_root`` is used. It uses ``xmss_sign_and_pkgen`` with an
+empty leaf index to only create the root node (see :ref:`SPHINCS+ Treehash
+<signatures/sphincsplus/treehash>` invoked by ``xmss_sign_and_pkgen``).
+Algorithm 10 (:math:`\mathtt{xmss\_pkFromSig}`), i.e., the reconstruction of an
+XMSS root node using an XMSS signature, is achieved by calling the function
+``compute_root`` (see :ref:`SPHINCS+ Treehash <signatures/sphincsplus/treehash>`).
+
+.. _signatures/sphincsplus/hypertree:
+
+Hypertree
+^^^^^^^^^
+
+The XMSS hypertree signature creation according to Algorithm 12 of [SPX-R3]_
+(:math:`\mathtt{ht\_sign}`) is implemented by the method ``ht_sign``. Beginning
+at the hypertree's leaves, the hypertree is built up using subsecutive calls of
+``xmss_sign_and_pkgen`` (see :ref:`SPHINCS+ XMSS <signatures/sphincsplus/XMSS>`)
+with each call signing the root of the previous XMSS tree or the hypertree
+signature's message for the first call. As described in :ref:`SPHINCS+ XMSS
+<signatures/sphincsplus/XMSS>`, this also creates the XMSS root node used in the
+next iteration. The leaf indices selected to sign the hypertree signature's
+message or roots are computed according to the specification.
+
+The hypertree verification, Algorithm 13  of [SPX-R3]_
+(:math:`\mathtt{ht\_verify}`), is performed in ``ht_verify``. By calling
+``compute_root``, it reconstructs the roots from bottom to top using the
+concatenated XMSS signatures. For verification, the final root, which is the
+root of the hypertree, is compared with :math:`\mathbf{PK}.\mathsf{root}`.
+
+.. _signatures/sphincsplus/sphincsplus:
+
+SPHINCS\ :sup:`+`
+^^^^^^^^^^^^^^^^^
+
+All the above components are combined to constitute Botan's SPHINCS\ :sup:`+`
+component used for creating or verifying SPHINCS\ :sup:`+` signatures.
+
+Signature Creation
+~~~~~~~~~~~~~~~~~~
+
+A SPHINCS\ :sup:`+` signature is created in the following manner, following
+Algorithm 20 of [SPX-R3]_:
+
+.. admonition:: SPHINCS+ Signature Creation
+
+   **Input:**
+
+   -  ``m``: message to be signed
+   -  ``SK``: SPHINCS\ :sup:`+` secret key, ``SK = {secret_seed, prf, public_seed, sphincs_root}``
+
+   **Output:**
+
+   -  ``sig``:  SPHINCS\ :sup:`+` signature
+
+   **Steps:**
+
+   1. ``opt_rand`` is set to ``SK.public_seed``. If the scheme is randomized, ``opt_rand`` is set to a freshly generated random byte vector.
+   2. ``msg_random_s = PRF_msg(m, SK.prf, opt_rand)`` and append ``msg_random_s`` to ``sig``.
+   3. ``mhash || tree_idx || leaf_idx = H_msg(msg_random_s, SK.sphincs_root, m)``.
+   4. Set type of ``fors_addr`` to FORS tree, its tree to ``tree_idx``, and its keypair address to ``leaf_idx``.
+   5. ``fors_sig, fors_root = fors_sign_and_pkgen(mhash, SK.secret_seed, fors_addr)`` and append ``fors_sig`` to ``sig``.
+   6. ``ht_sig = ht_sign(fors_root, SK.secret_seed, tree_idx, leaf_idx)`` and append ``ht_sig`` to ``sig``.
+
+   **Notes:**
+
+   - ``SK.public_seed`` is omitted as an input because the hash functions are already instantiated with a corresponding member variable.
+
+Signature Validation
+~~~~~~~~~~~~~~~~~~~~
+
+A SPHINCS\ :sup:`+` signature is verified in the following manner, following
+Algorithm 21 of [SPX-R3]_:
+
+.. admonition:: SPHINCS+ Signature Validation
+
+   **Input:**
+
+   -  ``m``: message to be validated
+   -  ``sig``: signature to be validated
+   -  ``PK``: SPHINCS\ :sup:`+` public key, ``PK = {public_seed, sphincs_root}``
+
+   **Output:**
+
+   -  ``true``, if the signature for message ``m`` is valid. ``false`` otherwise
+
+   **Steps:**
+
+   1. Take the first ``n`` bytes of ``sig`` as value ``msg_random_s``.
+   2. ``mhash || tree_idx || leaf_idx = H_msg(msg_random_s, PK.sphincs_root, m)``.
+   3. Set type of ``fors_addr`` to FORS tree, its tree to ``tree_idx``, and its keypair address to ``leaf_idx``.
+   4. Take the FORS signature bytes of ``sig`` as value ``fors_sig_s``.
+   5. ``fors_root = fors_public_key_from_signature(mhash, fors_sig_s, fors_addr)``.
+   6. Take the hypertree signature bytes of ``sig`` as value ``ht_sig_s``.
+   7. The signature is valid iff ``ht_verify(fors_root, ht_sig_s, PK.sphincs_root, tree_idx, lead_idx) = true``.
+
+   **Notes:**
+
+   - The lengths of the FORS and the hypertree signatures are precomputed in the ``Sphincs_Parameters`` object.
+   - ``PK.public_seed`` is omitted as an input because the hash functions are already instantiated with a corresponding member variable.

--- a/cryptodoc/src/08_signatures.rst
+++ b/cryptodoc/src/08_signatures.rst
@@ -866,12 +866,13 @@ To distinguish both cases with slightly different boundaries, :math:`\mathbf{w_1
 SPHINCS\ :sup:`+`
 -----------------
 
-SPHINCS\ :sup:`+` is composed of Forest Of Random Subset (FORS) signatures and
-Winternitz One-Time Signatures (WOTS\ :sup:`+`), which are used
-within hypertree signatures (a variant of XMSS\ :sup:`MT`). In short, messages
+SPHINCS\ :sup:`+` is composed of Forest Of Random Subsets (FORS) few-time signatures
+and Winternitz One-Time Signatures (WOTS\ :sup:`+`), which are used within
+hypertree signatures (a variant of XMSS\ :sup:`MT`). In short, messages
 are signed via FORS. The FORS public key is signed via XMSS with WOTS\ :sup:`+`
-as part of the hypertree and the overall root represents the SPHINCS\ :sup:`+`
-root. Table :ref:`SPHINCS+ logical components <signatures/sphincsplus/table>`
+as part of the hypertree. The root of the top-level tree in the hypertree
+structure then essentially represents the SPHINCS\ :sup:`+` root.
+Table :ref:`SPHINCS+ logical components <signatures/sphincsplus/table>`
 provides an overview of these components and their Botan implementations. The
 :ref:`SPHINCS+ <signatures/sphincsplus/sphincsplus>` component, by making use of
 the other components, provides the overall signature generation and verification
@@ -898,7 +899,7 @@ operations.
    +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
    | :ref:`WOTS+ <signatures/sphincsplus/wotsplus>`       | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_wots.h`       | WOTS\ :sup:`+` signature                   | 3                            |
    +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
-   | :ref:`XMSS <signatures/sphincsplus/xmss>`            | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_xmss.h`       |     XMSS    signature                      | 4.1                          |
+   | :ref:`XMSS <signatures/sphincsplus/xmss>`            | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_xmss.h`       | XMSS signature                             | 4.1                          |
    +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
    | :ref:`Hypertree <signatures/sphincsplus/hypertree>`  | :srcref:`src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hypertree.h`  | Hypertree signature                        | 4.2                          |
    +------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------+------------------------------+
@@ -976,9 +977,9 @@ calling the method ``T``, which allows for arbitrary input lengths.
 Treehash
 ^^^^^^^^
 
-Botan generalizes the treehash Algorithms 7  (:math:`\mathtt{treehash}`) and 15
+Botan generalizes the treehash Algorithms 7 (:math:`\mathtt{treehash}`) and 15
 (:math:`\mathtt{fors\_treehash}`) of [SPX-R3]_ using a single function
-``treehash``,  similar to SPHINCS\ :sup:`+`'s reference implementation. This
+``treehash``, similar to SPHINCS\ :sup:`+`'s reference implementation. This
 approach minimizes duplicate code while explicitly being in accordance with the
 specification (see Section 5.3 of [SPX-R3]_). The only difference between the
 treehash of FORS and XMSS is the creation of leaf nodes. Therefore, ``treehash``
@@ -1041,7 +1042,7 @@ fuses the WOTS\ :sup:`+` public key and signature creation, i.e., the algorithms
 one method. When building up an XMSS tree, all leaf nodes must be computed,
 which are the hashed WOTS\ :sup:`+` public keys. Only one leaf is used to sign
 the underlying root. The WOTS\ :sup:`+` signature consists of values that are
-computed in every public key creation; these values are part of the
+computed in every public key creation; these values are elements of the
 WOTS\ :sup:`+` hash chains. This observation leads to Botan's
 ``wots_sign_and_pkgen`` method that combines both logics, i.e., the entire
 WOTS\ :sup:`+` chains are computed for the public key while the WOTS\ :sup:`+`
@@ -1132,7 +1133,7 @@ Algorithm 20 of [SPX-R3]_:
 
    **Steps:**
 
-   1. ``opt_rand`` is set to ``SK.public_seed``. If the scheme is randomized, ``opt_rand`` is set to a freshly generated random byte vector.
+   1. ``opt_rand`` is set to ``SK.public_seed``. If the scheme is randomized, ``opt_rand`` is instead set to a freshly generated random byte vector.
    2. ``msg_random_s = PRF_msg(m, SK.prf, opt_rand)`` and append ``msg_random_s`` to ``sig``.
    3. ``mhash || tree_idx || leaf_idx = H_msg(msg_random_s, SK.sphincs_root, m)``.
    4. Set type of ``fors_addr`` to FORS tree, its tree to ``tree_idx``, and its keypair address to ``leaf_idx``.

--- a/cryptodoc/src/90_bibliographie.rst
+++ b/cryptodoc/src/90_bibliographie.rst
@@ -64,6 +64,11 @@
    https://ieeexplore.ieee.org/document/8637988,
    25 January 2019
 
+.. [IR-8413] NIST Interagency or Internal Report 8413 Upd. 1:
+   "Status Report on the Third Round of the NIST Post-Quantum Cryptography Standardization Process",
+   https://nvlpubs.nist.gov/nistpubs/ir/2022/NIST.IR.8413-upd1.pdf,
+   September 2022
+
 .. [ISO-9594-8] ISO/IEC 9594-8:2017:
    Information technology -- Open Systems Interconnection -- The Directory -- Part 8:
    Public-key and attribute certificate frameworks
@@ -193,6 +198,11 @@
    "Recommendation for Stateful Hash-Based Signature Schemes",
    https://csrc.nist.gov/publications/detail/sp/800-208/final,
    October 2020
+
+.. [SPX-R3] J.-P. Aumasson, D. J. Bernstein, W. Beullens, C. Dobraunig, M. Eichlseder, S. Fluhrer, S.-L. Gazdag, A. Hülsing, P. Kampanakis, S. Kölbl, T. Lange, M. M. Lauridsen, F. Mendel, R. Niederhagen, C. Rechberger, J. Rijneveld, P. Schwabe, B. Westerbaan:
+   "SPHINCS+ Submission to the NIST post-quantum project, v.3.1",
+   NIST PQC Challenge Round 3 Submission, 2021,
+   https://sphincs.org/data/sphincs+-r3.1-specification.pdf
 
 .. [TR-02102-1] BSI Technische Richtlinie BSI TR-02102-1:
    "Kryptographische Verfahren: Empfehlungen und Schlüssellängen",

--- a/cryptodoc/src/conf.py
+++ b/cryptodoc/src/conf.py
@@ -57,9 +57,20 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # -- Options for botan_src_path extension ------------------------------------
 
-src_ref_reference = '3.0.0'
-# src_ref_check_url = True
-
+# ATTENTION ON RELEASE
+# ATTENTION ON RELEASE
+# ATTENTION ON RELEASE
+#
+#   Change this to the Botan GitHub tag this document is referring to,
+#   before cutting a revision of the crypto documentation.
+#
+#   TODO: Add a more reliable way or some sort of checklist to avoid
+#         forgetting this before cuttung a release.
+#
+# ATTENTION ON RELEASE
+# ATTENTION ON RELEASE
+# ATTENTION ON RELEASE
+src_ref_reference = '3.1.1'
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Since the [PR for SPHINCS+](https://github.com/randombit/botan/pull/3549) for Botan is not merged yet, the CI pipeline currently fails; the source-links cannot be found. However, we expect that the PR is merged soon next week after some minor adjustments were made.