### PR TITLE
FIX: Clarify scope of the document

### DIFF
--- a/audit_report/3.0.0/src/01_method.rst
+++ b/audit_report/3.0.0/src/01_method.rst
@@ -32,8 +32,11 @@ unit and integration tests (in ``src/tests``, ``src/bogo_shim``,
 The review in this document keeps track of changes in all the above-mentioned
 components. For the library implementation itself (``src/lib``) all modules that
 are *required* or *available* in the BSI build policy and their dependencies are
-in the scope of this document. Patches that don't alter any of the
-above-mentioned components or relevant modules are considered out-of-scope.
+in the scope of this document. Additionally, we review the following modules and
+its dependencies: `getentropy`, `ffi`, `xts`, `pkcs11`, `tls12`, `tls13`,
+`tls_cbc`, `x509`, `certstor_windows`, `certstor_macos`, `certstor_flatfile`
+Patches that don't alter any of the above-mentioned components or relevant
+modules are considered out-of-scope.
 
 Below is the full list of modules (from ``src/lib``) whose changes were
 reviewed:


### PR DESCRIPTION
Previously, the introductory text could be understood as if only the relevant library modules are in scope of the review. This is false, also tests, CLI, python bindings, build system and documentation are explicitly reviewed.