### PR TITLE
FIX: missing return value in render_approvers()

### DIFF
--- a/audit_generator/genaudit/render.py
+++ b/audit_generator/genaudit/render.py
@@ -156,6 +156,9 @@ class Renderer:
             elif pr_info.merged_by and pr_info.user != pr_info.merged_by:
                 return [self._render_user(pr_info.merged_by)]
 
+            else:
+                return []
+
         def render_auditer(patch):
             if not patch.auditer:
                 return None


### PR DESCRIPTION
Minor fix that otherwise gets annoying in basically all audit PR to come today. Exceptionally merging without a review, due to Fronleichnam. :)