### PR TITLE
Audit: PBKDF

### DIFF
--- a/audit_report/3.0.0/changes/topics/pbkdf.yml
+++ b/audit_report/3.0.0/changes/topics/pbkdf.yml
@@ -1,39 +1,51 @@
 title: PBKDF
 
+description: |
+  Most notably, this provides a faster implementation of Argon2. This is
+  achieved by utilizing multithreading if the ``threads`` parameter is greater
+  than one. Additionally, SIMD implementations for Argon2's BLAMKA function were
+  added.
+
 patches:
 # Fix invocation of create_or_throw  (@Jack Lloyd)
 - commit: 9eba029ade68ce39f9ef320801b1a1ce656a086d  # https://github.com/randombit/botan/commit/9eba029ade68ce39f9ef320801b1a1ce656a086d
-  classification: unspecified
+  classification: info
+  auditer: reneme
 
 # Avoid calling deprecated function  (@Jack Lloyd)
 - commit: 6081828bcc168ec0898607c3ba6295b0f77ed250  # https://github.com/randombit/botan/commit/6081828bcc168ec0898607c3ba6295b0f77ed250
-  classification: unspecified
+  classification: info
+  auditer: reneme
 
 # Deprecate these PBKDF getters  (@Jack Lloyd)
 - commit: 6cab72f55f30210310c43b6b245215f0c36f0124  # https://github.com/randombit/botan/commit/6cab72f55f30210310c43b6b245215f0c36f0124
-  classification: unspecified
+  classification: info
+  auditer: reneme
 
 # Allow runtime configuration of PBKDF tuning runtime  (@randombit)
 - pr: 3401  # https://github.com/randombit/botan/pull/3401
   merge_commit: a54ea051ae17af17a98c2300c93589352d8b881a
-  classification: unspecified
+  classification: info
 
 # Add AVX2 implementation of Argon2's BLAMKA function  (@randombit)
 - pr: 3205  # https://github.com/randombit/botan/pull/3205
   merge_commit: e3a501c4915222f396839cb7844dc14042277580
-  classification: unspecified
+  classification: relevant
+  auditer: reneme
 
 # Enable 'argon2fmt' in the BSI build policy  (@reneme)
 - pr: 3014  # https://github.com/randombit/botan/pull/3014
   merge_commit: a901292e9e03fe01a3604cbc4357f0c6a66ba51d
-  classification: unspecified
+  classification: info
 
 # Add Argon2 SSSE3 implementation  (@randombit)
 - pr: 2927  # https://github.com/randombit/botan/pull/2927
   merge_commit: 4dd1d2ed11d1b88ae3c86da30f5a6a1c30579f82
-  classification: unspecified
+  classification: relevant
+  auditer: reneme
 
 # Add threading to Argon2  (@randombit)
 - pr: 2926  # https://github.com/randombit/botan/pull/2926
   merge_commit: bab40cdd29d19e0638cf1301dfd355c52b94d1c0
-  classification: unspecified
+  classification: relevant
+  auditer: reneme


### PR DESCRIPTION
Note that Argon2 was added to the BSI policy recently and will probably need a full review independent of this change-tracking audit.