### PR TITLE
Audit: add JSON Schema for topics and enable it for yml files

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "lextudio.restructuredtext",
         "trond-snekvik.simple-rst",
-        "editorconfig.editorconfig"
+        "editorconfig.editorconfig",
+        "redhat.vscode-yaml",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "esbonio.sphinx.confDir": "${workspaceFolder}/cryptodoc/src"
+    "esbonio.sphinx.confDir": "${workspaceFolder}/cryptodoc/src",
+    "yaml.schemas": {
+        "audit_generator/topic-schema.json": [
+            "audit_report/*/changes/topics/*.yml",
+        ],
+    },
 }

--- a/audit_generator/README.md
+++ b/audit_generator/README.md
@@ -33,7 +33,7 @@ classification: relevant
 patches:
 # Support hash truncation in ECKCDSA (#2742)  (@lieser)
 - pr: 3393  # GitHub pull request number
-  classification: relevant  # (or: 'unspecified', 'out_of_scope', 'info', 'critical')
+  classification: relevant  # (or: 'unspecified', 'out of scope', 'info', 'critical')
   comment: |
     Ensures that hash truncation in ECKCDSA is performed as specified in ISO
     14888-3:2016.

--- a/audit_generator/topic-schema.json
+++ b/audit_generator/topic-schema.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/sehlen-bsi/botan-docs/audit/topics-schema.json",
+    "title": "Audit topic",
+    "description": "A single topic for the BSI audit document of Botan.",
+    "type": "object",
+    "additionalProperties": false,
+    "$defs": {
+        "classification": {
+            "type": "string",
+            "enum": [
+                "unspecified",
+                "out of scope",
+                "critical",
+                "relevant",
+                "info"
+            ]
+        }
+    },
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "classification": {
+            "$ref": "#/$defs/classification"
+        },
+        "patches": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "oneOf": [
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "pr": {
+                                "type": "number"
+                            },
+                            "merge_commit": {
+                                "type": "string"
+                            },
+                            "classification": {
+                                "$ref": "#/$defs/classification"
+                            },
+                            "auditer": {
+                                "type": "string"
+                            },
+                            "comment": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "pr",
+                            "merge_commit"
+                        ]
+                    },
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "commit": {
+                                "type": "string"
+                            },
+                            "classification": {
+                                "$ref": "#/$defs/classification"
+                            },
+                            "auditer": {
+                                "type": "string"
+                            },
+                            "comment": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "commit"
+                        ]
+                    }
+                ],
+                "required": [
+                    "classification"
+                ]
+            }
+        }
+    },
+    "required": [
+        "title",
+        "patches"
+    ]
+}


### PR DESCRIPTION
[JSON Schema](https://json-schema.org/) can be used to not just validate JSON, but als YAML files. The YAML extension of VS Code supports this.
Use this to to add auto completion and validation of the topic files in local development.

- Adds the YAML extension to the list of recommended extensions.
- Add a JSON Schema for topics.
- Enable the JSON Schema for the YAML files of the topics in the audit report.