### PR TITLE
FIX: Caching of pygithub requests

### DIFF
--- a/audit_generator/genaudit/cache.py
+++ b/audit_generator/genaudit/cache.py
@@ -11,7 +11,14 @@ from github import Requester, Consts
 
 class CachingRequester(Requester.Requester):
     def __init__(self, login_or_token, cache_location):
-        super().__init__(login_or_token, None, None, None, Consts.DEFAULT_BASE_URL, Consts.DEFAULT_TIMEOUT, "PyGithub-genaudit/Python", Consts.DEFAULT_PER_PAGE, True, None, None)
+        super().__init__(login_or_token,
+                         Consts.DEFAULT_BASE_URL,
+                         Consts.DEFAULT_TIMEOUT,
+                         Consts.DEFAULT_USER_AGENT,
+                         Consts.DEFAULT_PER_PAGE,
+                         True, # verify
+                         None,
+                         None)
 
         # The regexes should have one or more match groups that will be used as
         # the key in the underlying cache. Multiple match groups will be

--- a/audit_generator/genaudit/repo.py
+++ b/audit_generator/genaudit/repo.py
@@ -9,6 +9,7 @@ from github.PullRequest import PullRequest
 from github.PullRequestReview import PullRequestReview
 from github.Commit import Commit
 from github.NamedUser import NamedUser
+from github.Auth import Token
 from github import Github
 
 from genaudit import util
@@ -25,7 +26,7 @@ class GitRepo:
         self.local_repo_root = local_repo_root
         self.github_handle = github_handle
         self.main_branch = main_branch
-        self.connection = CachingGithub(github_token, cache_location)
+        self.connection = CachingGithub(Token(github_token), cache_location)
 
         self.repo = self.connection.get_repo(self.github_handle)
 

--- a/audit_generator/requirements.txt
+++ b/audit_generator/requirements.txt
@@ -1,3 +1,3 @@
-pygithub>=1.58
+pygithub>=1.59
 pyyaml>=6.0
 Jinja2>=3.0


### PR DESCRIPTION
We hacked the pygithub library somewhat to allow caching of requests. Apparantly they did some refactoring in their internal implementation that broke our hack (when going from pygithub 1.58 to 1.59).

After this is merged, open pull requests will need to be rebased to fix their Audit builds.