### PR TITLE
Audit: Update patch coverage to Botan 3.1.0

### DIFF
--- a/audit_report/3.1.0/changes/config.yml
+++ b/audit_report/3.1.0/changes/config.yml
@@ -4,10 +4,7 @@ repo:
   github_handle:  randombit/botan
   local_checkout: ../_build/botan
   audit_ref_from: 3.0.0-alpha1
-
-  # Tip of `master` on the 21st of June 2023
-  # TODO: change that to 3.1.0 (or further intermediate steps) eventually
-  audit_ref_to:   99dbdd53a9a9ac66e4d4fe710413bb7402f6cb95
+  audit_ref_to:   3.1.0
 
 topics: topics
 cache: ../_build/audit_generator_cache

--- a/audit_report/3.1.0/changes/topics/auxiliary_scripts.yml
+++ b/audit_report/3.1.0/changes/topics/auxiliary_scripts.yml
@@ -48,3 +48,8 @@ patches:
 # Add a script to analyze output of `botan timing_test` [ci skip]  (@Jack Lloyd)
 - commit: 49cb42470d670f9c9b102a2c5bbf0492d9f9254a  # https://github.com/randombit/botan/commit/49cb42470d670f9c9b102a2c5bbf0492d9f9254a
   classification: unspecified
+
+# Generate .clang-tidy files from run_clang_tidy.py  (@reneme)
+- pr: 3592  # https://github.com/randombit/botan/pull/3592
+  merge_commit: 63cd7a25828de02c921efa3a3d08862ff2bfdcaf
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/build_system.yml
+++ b/audit_report/3.1.0/changes/topics/build_system.yml
@@ -216,3 +216,24 @@ patches:
 # Fix variable reference in exception  (@Jack Lloyd)
 - commit: 3acee255dab73c1e066b8be038f967571f0e5bcf  # https://github.com/randombit/botan/commit/3acee255dab73c1e066b8be038f967571f0e5bcf
   classification: unspecified
+
+# Fix up XCode detection a bit  (@randombit)
+- pr: 3597  # https://github.com/randombit/botan/pull/3597
+  merge_commit: 7ffba4fdee8b830710431e5f2f44333ade5ebab2
+  classification: unspecified
+
+# Add a 'tidy' make target [ci skip]  (@Jack Lloyd)
+- commit: 963c16c7b13563ed0dc3c2e94dadcf776e03413c  # https://github.com/randombit/botan/commit/963c16c7b13563ed0dc3c2e94dadcf776e03413c
+  classification: unspecified
+
+# Fix quoting  (@Jack Lloyd)
+- commit: f6a9834545bcefed38274e8a46aa66bd377e0544  # https://github.com/randombit/botan/commit/f6a9834545bcefed38274e8a46aa66bd377e0544
+  classification: unspecified
+
+# Rephrase this log line  (@Jack Lloyd)
+- commit: fa9972e3a6365c40cafc7cb9913534688a8f2b7f  # https://github.com/randombit/botan/commit/fa9972e3a6365c40cafc7cb9913534688a8f2b7f
+  classification: unspecified
+
+# Fix compile_commands.json  (@Jack Lloyd)
+- commit: d7f54291d485f48b075733a758747f31e13e8312  # https://github.com/randombit/botan/commit/d7f54291d485f48b075733a758747f31e13e8312
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/ci.yml
+++ b/audit_report/3.1.0/changes/topics/ci.yml
@@ -254,3 +254,8 @@ patches:
 # Use coverage badge from shields.io [ci skip]  (@Jack Lloyd)
 - commit: 3364d87e662b8cdfe2ab5bd9477d59470168e4c6  # https://github.com/randombit/botan/commit/3364d87e662b8cdfe2ab5bd9477d59470168e4c6
   classification: unspecified
+
+# Update CI to XCode 14.3  (@randombit)
+- pr: 3598  # https://github.com/randombit/botan/pull/3598
+  merge_commit: 7451323ce2329709ef1a02fa2f70ed57bf157f67
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/clang_format.yml
+++ b/audit_report/3.1.0/changes/topics/clang_format.yml
@@ -93,3 +93,7 @@ patches:
   classification: info
   auditer: FAlbertDev
   comment: Manually fix unwanted clang-format formatting
+
+# Fix formatting weirdness in psk_db.h  (@Jack Lloyd)
+- commit: 6cf5abeaf0d452d030f44f1de109c2fdbcc6bd54  # https://github.com/randombit/botan/commit/6cf5abeaf0d452d030f44f1de109c2fdbcc6bd54
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/code_chores.yml
+++ b/audit_report/3.1.0/changes/topics/code_chores.yml
@@ -623,3 +623,53 @@ patches:
 - commit: 3561957052a3a1c8a55198ca0bd2577ecfd9f307  # https://github.com/randombit/botan/commit/3561957052a3a1c8a55198ca0bd2577ecfd9f307
   classification: info
   auditer: FAlbertDev
+
+# Fix some clang-tidy warnings in ARM specific code  (@randombit)
+- pr: 3603  # https://github.com/randombit/botan/pull/3603
+  merge_commit: 2f51bce338913663213455756dd16f284e253045
+  classification: unspecified
+
+# Fix clang-tidy warnings in the compression code  (@randombit)
+- pr: 3602  # https://github.com/randombit/botan/pull/3602
+  merge_commit: d638bcdefeddc0d7b1053a172df81eef8dfc64aa
+  classification: unspecified
+
+# Fix clang-tidy warnings in some asio specific tests  (@randombit)
+- pr: 3601  # https://github.com/randombit/botan/pull/3601
+  merge_commit: 3c2b9c57c824c5a21d7490906af26e33a22d239f
+  classification: unspecified
+
+# Further clang-tidy fixes  (@randombit)
+- pr: 3600  # https://github.com/randombit/botan/pull/3600
+  merge_commit: e6b379b30b690a439b19749ef856a88c61e3bbb1
+  classification: unspecified
+
+# Improve clang-tidy coverage  (@randombit)
+- pr: 3595  # https://github.com/randombit/botan/pull/3595
+  merge_commit: cbfbfa15503b7901976d7dbf18e3d5801e5e18c9
+  classification: unspecified
+
+# Chore: Make clang-tidy believe that StrongSpan<> really is cheap to copy  (@reneme)
+- pr: 3593  # https://github.com/randombit/botan/pull/3593
+  merge_commit: 92171c524519fd225be3cc55fe289c5ad28ff0b7
+  classification: unspecified
+
+# Small macro cleanup  (@Jack Lloyd)
+- commit: b510d4c398807bfed329e4620ce38011e7f43724  # https://github.com/randombit/botan/commit/b510d4c398807bfed329e4620ce38011e7f43724
+  classification: unspecified
+
+# Fix one more clang-tidy warning  (@Jack Lloyd)
+- commit: 73ad31acf0789a1c10e29121ab42a9f18e8b33b8  # https://github.com/randombit/botan/commit/73ad31acf0789a1c10e29121ab42a9f18e8b33b8
+  classification: unspecified
+
+# Disable pylint too-many-return-statements  (@Jack Lloyd)
+- commit: c12cab94dbcbd3edc82b610356d8fbe6b244425e  # https://github.com/randombit/botan/commit/c12cab94dbcbd3edc82b610356d8fbe6b244425e
+  classification: unspecified
+
+# Fix another clang-tidy warning  (@Jack Lloyd)
+- commit: e15c45c297e930ac62c5575848f3c0c350249503  # https://github.com/randombit/botan/commit/e15c45c297e930ac62c5575848f3c0c350249503
+  classification: unspecified
+
+# Fix some clang-tidy warnings that popped up in the nightly run  (@Jack Lloyd)
+- commit: d09bff761e819a5937883051090ede59050aaaaa  # https://github.com/randombit/botan/commit/d09bff761e819a5937883051090ede59050aaaaa
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/documentation.yml
+++ b/audit_report/3.1.0/changes/topics/documentation.yml
@@ -263,3 +263,28 @@ patches:
 - commit: 66acd0e6868223cd12607555cd7da2223cc4924d  # https://github.com/randombit/botan/commit/66acd0e6868223cd12607555cd7da2223cc4924d
   classification: info
   auditer: reneme
+
+# Add some examples of how to write a custom entropy source  (@randombit)
+- pr: 3606  # https://github.com/randombit/botan/pull/3606
+  merge_commit: 4eb70d21a1fc916cfe0df4ec163938ff218ea0bb
+  classification: unspecified
+
+# Clarify that we actually need at least GCC 11.2 [ci skip]  (@Jack Lloyd)
+- commit: c2521c323d18a677ba4fa6905769f25824f3fe7d  # https://github.com/randombit/botan/commit/c2521c323d18a677ba4fa6905769f25824f3fe7d
+  classification: unspecified
+
+# Update todos [ci skip]  (@Jack Lloyd)
+- commit: 1892840be8300e24c6a2b0abfa9424cbbc9b497e  # https://github.com/randombit/botan/commit/1892840be8300e24c6a2b0abfa9424cbbc9b497e
+  classification: unspecified
+
+# Update todo  (@Jack Lloyd)
+- commit: 4af92f41de05fc8c9f0a97d545172eaaaf977017  # https://github.com/randombit/botan/commit/4af92f41de05fc8c9f0a97d545172eaaaf977017
+  classification: unspecified
+
+# Call out that the NDK/XCode minimum version is floating [ci skip]  (@Jack Lloyd)
+- commit: bc5e1c87093ea71b738066341edf3d0213562cc7  # https://github.com/randombit/botan/commit/bc5e1c87093ea71b738066341edf3d0213562cc7
+  classification: unspecified
+
+# Update readme [ci skip]  (@Jack Lloyd)
+- commit: f5fb96c39fe83edcbc8206dbdc9e159edde0e77c  # https://github.com/randombit/botan/commit/f5fb96c39fe83edcbc8206dbdc9e159edde0e77c
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/fixes.yml
+++ b/audit_report/3.1.0/changes/topics/fixes.yml
@@ -117,3 +117,12 @@ patches:
 - pr: 3586  # https://github.com/randombit/botan/pull/3586
   merge_commit: 5288e84e1ed9702092e034bef8a43c615480bd57
   classification: unspecified
+
+# Fix BigInt::random_integer logic that can cause slow execution  (@randombit)
+- pr: 3594  # https://github.com/randombit/botan/pull/3594
+  merge_commit: e16e58a368014c4f062c2342f108cbca90e55f46
+  classification: unspecified
+
+# Add an assert before jumping to CPU ghash impl  (@Jack Lloyd)
+- commit: d6912de4e4b71f10cc76e6bb7c068ff09cadba7d  # https://github.com/randombit/botan/commit/d6912de4e4b71f10cc76e6bb7c068ff09cadba7d
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/release.yml
+++ b/audit_report/3.1.0/changes/topics/release.yml
@@ -98,3 +98,15 @@ patches:
 - commit: 7bf53621be808192fdb87832c5317178fa2c6ef7  # https://github.com/randombit/botan/commit/7bf53621be808192fdb87832c5317178fa2c6ef7
   classification: info
   auditer: reneme
+
+# Update for 3.1.0 release  (@Jack Lloyd)
+- commit: c6a09af66a77fca62bbd85242192fa045d04a5b3  # https://github.com/randombit/botan/commit/c6a09af66a77fca62bbd85242192fa045d04a5b3
+  classification: unspecified
+
+# Update changelog  (@Jack Lloyd)
+- commit: 682f88be390151cc7814975c569e81fc29d80222  # https://github.com/randombit/botan/commit/682f88be390151cc7814975c569e81fc29d80222
+  classification: unspecified
+
+# Update release notes [ci skip]  (@Jack Lloyd)
+- commit: 0eeb41761250169c75594b2d54a002198dbaf78c  # https://github.com/randombit/botan/commit/0eeb41761250169c75594b2d54a002198dbaf78c
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/sphincsplus.yml
+++ b/audit_report/3.1.0/changes/topics/sphincsplus.yml
@@ -17,3 +17,7 @@ patches:
 - pr: 3564  # https://github.com/randombit/botan/pull/3564
   merge_commit: 1cbeffafb28214533b27157a87f2a9dcb91a068a
   classification: info
+
+# Add SPHINCS+ speed run to the CLI tests  (@Jack Lloyd)
+- commit: 59cb03996b6d308485b847b0aade46e6d124a29c  # https://github.com/randombit/botan/commit/59cb03996b6d308485b847b0aade46e6d124a29c
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/test_framework.yml
+++ b/audit_report/3.1.0/changes/topics/test_framework.yml
@@ -49,3 +49,8 @@ patches:
 - pr: 3583  # https://github.com/randombit/botan/pull/3583
   merge_commit: 9bf2f5456d4af67b112b35fa9208265d7353992b
   classification: unspecified
+
+# Use deterministic port numbers for the CLI tests  (@randombit)
+- pr: 3596  # https://github.com/randombit/botan/pull/3596
+  merge_commit: eac046cee93930d51cdebba3d1c4534949f163de
+  classification: unspecified

--- a/audit_report/3.1.0/changes/topics/tls.yml
+++ b/audit_report/3.1.0/changes/topics/tls.yml
@@ -346,3 +346,28 @@ patches:
     ``Credentials_Manager::trusted_certificate_authorities()`` callback. Also
     fixes a parsing issue in OCSP responses where Botan excepted responses that
     identify the responder certificate both by name and key hash.
+
+# [TLS 1.3] Use a KEM interface in the Callbacks  (@reneme)
+- pr: 3608  # https://github.com/randombit/botan/pull/3608
+  merge_commit: cf8d8a6ca86e50708e6b4e0122f08a775362ec80
+  classification: unspecified
+
+# Chore: Update BoGo tests  (@reneme)
+- pr: 3616  # https://github.com/randombit/botan/pull/3616
+  merge_commit: 85406718a30f713ee8768a4371a5edd26e663b28
+  classification: unspecified
+
+# [TLS 1.3] Preparations for externally provided PSKs  (@reneme)
+- pr: 3617  # https://github.com/randombit/botan/pull/3617
+  merge_commit: 3a70598f9381278eb77551e4487a447e69256e5e
+  classification: unspecified
+
+# Fix some clang-tidy warnings in the TLS 1.3 PSK extension code  (@randombit)
+- pr: 3619  # https://github.com/randombit/botan/pull/3619
+  merge_commit: dc3a37d2d3901160e293f3d91cee143ce9ee300c
+  classification: unspecified
+
+# Fix clang-tidy warnings in tls_client_impl_12.cpp  (@randombit)
+- pr: 3605  # https://github.com/randombit/botan/pull/3605
+  merge_commit: 19b605dcb6ee967fe9645cd49548c4bd40a1934f
+  classification: unspecified


### PR DESCRIPTION
The document now covers all patches applied to the code base between `3.0.0-alpha1` and `3.1.0`.

For the record:

* 184 plain commits to master
* 434 merged pull requests
* 23 individual contributors
* 2032 files changed
* 194075 lines inserted
* 114684 lines deleted

Note that the diff stat is highly skewed by the introduction of clang-format.