### PR TITLE
FIX: Store cache if building fails due to rate limit

### DIFF
--- a/.github/scripts/query_rate_limit.sh
+++ b/.github/scripts/query_rate_limit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script queries the current GitHub API rate limit and makes
+# it available to consecutive actions as environment variables
+
+read_limit() {
+    local limit_json="$1"
+    local limit_filter="$2"
+    echo "$limit_json" | jq "$limit_filter"
+}
+
+limits="$(gh api rate_limit)"
+
+remaining=$(read_limit "$limits" ".resources.core.remaining")
+used=$(read_limit "$limits" ".resources.core.used")
+limit=$(read_limit "$limits" ".resources.core.limit")
+exceeded=$(test $remaining -eq 0 && echo 'true' || echo 'false')
+
+echo "API_RATE_LIMIT_REMAINING=$remaining" >> $GITHUB_ENV
+echo "API_RATE_LIMIT_USED=$used" >> $GITHUB_ENV
+echo "API_RATE_LIMIT=$limit" >> $GITHUB_ENV
+echo "API_RATE_LIMIT_EXCEEDED=$exceeded" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,19 @@ jobs:
           AUDIT_REPO_LOCATION: ${{ github.workspace }}/botan
           BASIC_GH_TOKEN: ${{ github.token }}
 
+      - name: Query the API Rate Limit
+        run: ${{ github.workspace }}/source/.github/scripts/query_rate_limit.sh
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Store Audit Generator Cache on Rate Limit Exceeded
+        uses: actions/cache/save@v3
+        if: ${{ failure() && env.API_RATE_LIMIT_EXCEEDED == 'true' }}
+        with:
+          path: ./audit_generator_cache
+          key: audit_3.1-${{ github.run_id }}
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/audit_generator/audit.py
+++ b/audit_generator/audit.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from github.PullRequest import PullRequest
 from github.Commit import Commit
+from github.GithubException import RateLimitExceededException
 
 import genaudit
 
@@ -176,6 +177,11 @@ def main():
         logging.info("Current GitHub API rate limit: %d/%d (will reset in: %d hours %d minutes)", rate_limit.remaining, rate_limit.limit, reset_time_h, reset_time_m)
 
         return args.func(audit, repo, args)
+    except RateLimitExceededException:
+        rate_limit = repo.rate_limit()
+        reset_time_m = (rate_limit.reset - datetime.now()).seconds / 60
+        logging.error("API rate limit exceeded (will reset in %d minutes)" % reset_time_m)
+        return 1
     finally:
         logging.info("Performed %d API requests (%.1f%% cache hits)", repo.api_request_count(), repo.api_cache_hit_rate() * 100)
 


### PR DESCRIPTION
That's a second attempt (after #76) to work around the tight rate limit on the GitHub API. The idea: if the build job fails due to the rate limit exceeding, we store the (partial) disk cache of the generator script. Later runs of the build pipeline will be able to pick this up and (hopefully) complete the job from where the previous job had failed.

Closes #74 