### PR TITLE
Audit: fixes.yml misses one review

### DIFF
--- a/audit_report/3.1.0/changes/topics/fixes.yml
+++ b/audit_report/3.1.0/changes/topics/fixes.yml
@@ -116,7 +116,9 @@ patches:
 # FIX: minor quirks in DL Scheme implementation  (@reneme)
 - pr: 3586  # https://github.com/randombit/botan/pull/3586
   merge_commit: 5288e84e1ed9702092e034bef8a43c615480bd57
-  classification: unspecified
+  classification: info
+  comment: |
+    Implementation did not change, just some additional sanity checks.
 
 # Fix BigInt::random_integer logic that can cause slow execution  (@randombit)
 - pr: 3594  # https://github.com/randombit/botan/pull/3594


### PR DESCRIPTION
... that'll be the last patch review for Botan 3.1.1

# 🥳 🥳 