### PR TITLE
FIX: Headline is needed in each chapter when building HTML

### DIFF
--- a/audit_report/3.1.0/src/07_bibliography.rst
+++ b/audit_report/3.1.0/src/07_bibliography.rst
@@ -1,5 +1,8 @@
 .. only:: not latex
 
+   Bibliography
+   ============
+
 .. [PRM] René Fischer, Juraj Somorvsky, Daniel Neus, Phillippe Lieser, René Meusel:
    "Pflege und Weiterentwicklung der Kryptobibliothek Botan (Weiterentwicklung Botan):
    Prüfmethodik für die Freigabe neuer Botan-Versionen",


### PR DESCRIPTION
When building the audit report with `make html` it complained that:

```
/home/meusel/Projects/BSI/botan-cryptodoc/docs/audit_report/src/index.rst:5: WARNING: toctree contains reference to document '07_bibliography' that doesn't have a title: no link will be generated
```