### PR TITLE
FIX: set esbonio.sphinx.confDir for new repo structure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "esbonio.sphinx.confDir": "${workspaceFolder}/cryptodoc/src",
+    "esbonio.sphinx.confDir": "${workspaceFolder}/docs/cryptodoc/src",
     "yaml.schemas": {
         "audit_generator/topic-schema.json": [
             "audit_report/*/changes/topics/*.yml",


### PR DESCRIPTION
This is an attempt to fix the rST language server (esbonio). Main obstacle: How to teach the language server to run `conf.py` inside the python venv created by `poetry shell` or maybe `poetry run`?