### PR TITLE
Pull the Botan target info from a central config file

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,21 @@
+
+name: Setup CI Environment
+description: Set up a build agent with the required environment
+
+inputs:
+  env_file:
+    description: The .env file containing the environment variables to be provisioned
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set Environment Variables
+      run: python3 ${{ github.workspace }}/.github/scripts/read_environment.py ${{ inputs.env_file }} >> $GITHUB_ENV
+      shell: bash
+      if: runner.os != 'Windows'
+
+    - name: Set Environment Variables
+      run: python3 ${{ github.workspace }}/.github/scripts/read_environment.py ${{ inputs.env_file }} >> $GITHUB_ENV
+      shell: pwsh
+      if: runner.os == 'Windows'

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -11,11 +11,11 @@ runs:
   using: composite
   steps:
     - name: Set Environment Variables
-      run: python3 ${{ github.workspace }}/.github/scripts/read_environment.py ${{ inputs.env_file }} >> $GITHUB_ENV
+      run: python3 ${{ github.action_path }}/../../scripts/read_environment.py ${{ inputs.env_file }} >> $GITHUB_ENV
       shell: bash
       if: runner.os != 'Windows'
 
     - name: Set Environment Variables
-      run: python3 ${{ github.workspace }}/.github/scripts/read_environment.py ${{ inputs.env_file }} >> $GITHUB_ENV
+      run: python3 ${{ github.action_path }}/../../scripts/read_environment.py ${{ inputs.env_file }} >> $GITHUB_ENV
       shell: pwsh
       if: runner.os == 'Windows'

--- a/.github/environment/botan.env
+++ b/.github/environment/botan.env
@@ -1,0 +1,14 @@
+# The GitHub reference of the Botan target repository.
+BOTAN_REPO=randombit/botan
+
+# The version of Botan that is currently being targeted by this documentation.
+# This must be a semver version string and will be printed (among other
+# things) as the reference version in the final document outputs. As such, it
+# might be a preliminary version that is still in development.
+BOTAN_VERSION=3.1.1
+
+# The concrete Botan repository reference that is currently used in the
+# creation of source-code related document generation. Once a Botan release is
+# minted, this may be the git-tag of that release. During development of an
+# upcoming version it should be a concrete commit SHA on Botan's main branch.
+BOTAN_REF=3.1.1

--- a/.github/scripts/read_environment.py
+++ b/.github/scripts/read_environment.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+if len(sys.argv) != 2 or not os.path.isfile(sys.argv[1]):
+    print(f"Usage: {sys.argv[0]} <path to .env file>")
+    sys.exit(1)
+
+def is_relevant(line: str) -> bool:
+    comment = line.startswith("#")
+    empty = line.startswith("\n")
+    return not comment and not empty
+
+with open(sys.argv[1], encoding='utf-8') as env_file:
+    [print(line.strip()) for line in env_file.readlines() if is_relevant(line)]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: botan_${{ matrix.element.out_name }}-${{ github.sha }}
+          name: Botan ${{ env.BOTAN_VERSION }} ${{ matrix.element.name }}
           path: ${{ matrix.element.dir }}/_build/latex/${{ matrix.element.out_name }}.pdf
 
   url_check:
@@ -141,5 +141,5 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: botan_audit_${{ github.sha }}
+          name: Botan ${{ env.BOTAN_VERSION }} Audit Report
           path: source/docs/audit_report/_build/latex/*.pdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
         working-directory: ${{matrix.element.dir }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Environment Configuration
+        uses: ./.github/actions/setup-environment
+        with:
+          env_file: ./.github/environment/botan.env
+
       - name: Install Build Dependencies
         run: |
           sudo apt-get update
@@ -53,6 +59,12 @@ jobs:
         working-directory: ${{matrix.element.dir }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Environment Configuration
+        uses: ./.github/actions/setup-environment
+        with:
+          env_file: ./.github/environment/botan.env
+
       - name: Install Build Dependencies
         run: |
           sudo apt-get update
@@ -70,11 +82,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ./source
+
+      - name: Setup Environment Configuration
+        uses: ./source/.github/actions/setup-environment
+        with:
+          env_file: ./source/.github/environment/botan.env
+
       - name: Fetch Botan Repository
         uses: actions/checkout@v3
         with:
           path: ./botan
-          repository: randombit/botan
+          repository: ${{ env.BOTAN_REPO }}
           fetch-depth: 0
 
       - name: Install Build Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,6 @@ permissions:
   contents: read
   # implicitly all other scopes not listed become none
 
-env:
-  BOTAN_REPO: randombit/botan
-  BOTAN_REF: 3.1.1
-
 jobs:
   utility:
     name: "Utility"
@@ -36,6 +32,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ./source
+
+      - name: Setup Environment Configuration
+        uses: ./source/.github/actions/setup-environment
+        with:
+          env_file: ./source/.github/environment/botan.env
+
       - name: Fetch Botan Repository
         uses: actions/checkout@v3
         with:
@@ -87,6 +89,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ./source
+
+      - name: Setup Environment Configuration
+        uses: ./source/.github/actions/setup-environment
+        with:
+          env_file: ./source/.github/environment/botan.env
+
       - name: Fetch Botan Repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This stashes the base information about the Botan repo, the source code version and git reference into a central config file. A small custom action reads this config file and puts to contained info into environment variables for later consumption by the CI jobs.