### PR TITLE
Set up a multi-root workspace that switches .venvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/_build/
 **/__pycache__/*
 *.pyc
+**/.venv/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,5 +4,7 @@
         "trond-snekvik.simple-rst",
         "editorconfig.editorconfig",
         "redhat.vscode-yaml",
+        "ms-python.python",
+        "david1542.poetrix",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
-    "esbonio.sphinx.confDir": "${workspaceFolder}/docs/cryptodoc/src",
     "yaml.schemas": {
         "audit_generator/topic-schema.json": [
             "audit_report/*/changes/topics/*.yml",
         ],
-    },
+    }
 }

--- a/docs/architecture/poetry.toml
+++ b/docs/architecture/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/docs/audit_method/poetry.toml
+++ b/docs/audit_method/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/docs/audit_report/poetry.toml
+++ b/docs/audit_report/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/docs/cryptodoc/poetry.toml
+++ b/docs/cryptodoc/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/docs/hybrid_tls_approaches/poetry.toml
+++ b/docs/hybrid_tls_approaches/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/docs/testspec/poetry.toml
+++ b/docs/testspec/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/mono.code-workspace
+++ b/mono.code-workspace
@@ -1,0 +1,16 @@
+{
+    "folders": [
+        {"path": ".", "name": "All"},
+        {"path": "docs/architecture", "name": "Doc: Architecture Overview"},
+        {"path": "docs/audit_method", "name": "Doc: Audit Method Description"},
+        {"path": "docs/audit_report", "name": "Doc: Audit Report"},
+        {"path": "docs/cryptodoc", "name": "Doc: Cryptographic Documentation"},
+        {"path": "docs/testspec", "name": "Doc: Test Specification"},
+        {"path": "tools/genaudit", "name": "Tool: genaudit"},
+        {"path": "tools/auditinfo", "name": "Tool: auditinfo"},
+        {"path": "tools/sourceref", "name": "Sphinx Extension: sourceref"},
+    ],
+    "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python3",
+    }
+}

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/tools/auditinfo/poetry.toml
+++ b/tools/auditinfo/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/tools/genaudit/poetry.toml
+++ b/tools/genaudit/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true

--- a/tools/sourceref/poetry.toml
+++ b/tools/sourceref/poetry.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+virtualenvs.in-project = true
+
+[virtualenvs]
+in-project = true


### PR DESCRIPTION
This is an attempt to use [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) in VS Code to automagically switch between python venvs.

The idea: Convince poetry to [manage the venvs "in-project"](https://python-poetry.org/docs/configuration/#virtualenvsin-project) (using local `poetry.toml` files) and use a multi-root workspace file to configure VS Code to find the interpreter in the `.venv` folder of the respective sub-directory (using `mono.code-workspace`).

A multi-root workspace provides an individual file tree pane for each "sub workspace", that might require some getting used to. On the other hand: the verbose sub-workspace name is actually quite ergonomic. One has to open the `mono.code-workspace` file (instead of just the directory) using VS Code.

![image](https://github.com/sehlen-bsi/botan-docs/assets/1562139/f5d60b3b-e4a3-4fe5-af0c-b338158cd6e8)


After `poetry install`-ing all the `.venv`s once, this switches the python interpreter reliably when navigating from file to file. Intellisense works as expected. One big caveat: Apparently esbonio isn't prepared to use multi-root workspaces. :(