### PR TITLE
FIX: Environment Configuration on Windows

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -16,6 +16,6 @@ runs:
       if: runner.os != 'Windows'
 
     - name: Set Environment Variables
-      run: python3 ${{ github.action_path }}/../../scripts/read_environment.py ${{ inputs.env_file }} >> $GITHUB_ENV
+      run: python3 ${{ github.action_path }}/../../scripts/read_environment.py ${{ inputs.env_file }}  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
       shell: pwsh
       if: runner.os == 'Windows'


### PR DESCRIPTION
There might be easier ways to do that in powershell than [the one I found here](https://www.jamescroft.co.uk/setting-github-actions-environment-variables-in-powershell/). For instance, we could pass the `$GITHUB_ENV` file path straight to the `read_environment.py` and implement the file append/write in Python. But frankly: 😴.