### PR TITLE
Hack: Keep GitHub Actions caches warm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,14 @@
 name: CI
 
 on:
-  push
+  push:
+  schedule:
+    # Run this around 2:37am once every 6-ish days to keep the GitHub API
+    # cache warm. Otherwise we would run into an API rate limit whenever
+    # we resume working on the repository after a weeks-long break.
+    #
+    # Github Actions caches are evicted after one week of not being used.
+    - cron: '37 2 1,7,13,19,25,31 * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
This runs the main build pipeline every 6-ish days to save the main branch's build cache from eviction when no-one works on this repository. Note that after about 60 days of repository inactivity GitHub will also suspend scheduled workflows. But that's a more realistic time window for consecutive edits of the documentation.

Admittedly, that's an evil hack. But I didn't find a way to manipulate the cache eviction policy.