### PR TITLE
Chore: Global Substitutions in rST

### DIFF
--- a/docs/architecture/src/01_architecture.rst
+++ b/docs/architecture/src/01_architecture.rst
@@ -1,6 +1,14 @@
 Botan Architecture
 ==================
 
+Document Revision
+-----------------
+
+This document was generated on |document_datestamp| based on the git revision |document_gitsha_short|.
+
+Introduction
+------------
+
 Botan consists of three main parts: the library itself, a CLI tool, and the test suite.
 The library itself is divided into separate modules.
 Botan uses a homebrew build system allowing for fine-grained configuration of the desired algorithms being built.

--- a/docs/architecture/src/conf.py
+++ b/docs/architecture/src/conf.py
@@ -28,6 +28,7 @@ author = 'Rohde & Schwarz'
 # The full version, including alpha/beta/rc tags
 release = auditinfo.botan_version()
 
+rst_prolog = auditinfo.rst_substitutions()
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/audit_method/src/00_00_preface.rst
+++ b/docs/audit_method/src/00_00_preface.rst
@@ -1,7 +1,7 @@
 Vorwort
 =======
 
-**Zusammefassung**
+**Zusammenfassung**
 
 Mit Botan steht eine vom BSI geprüfte Kryptobibliothek zur Verfügung. Mit
 dem  Einsatz von Botan durch Herstellern von VS-Produkten kann der

--- a/docs/audit_method/src/00_00_preface.rst
+++ b/docs/audit_method/src/00_00_preface.rst
@@ -24,6 +24,10 @@ Botan-Versionen zum Einsatz kommt.
 | Philippe Lieser (PL)
 | René Meusel (RM)
 
+**Dokumentrevision**
+
+Dieses Dokument wurde am |document_datestamp| aus der Git Revision |document_gitsha_short| erzeugt.
+
 **Copyright**
 
 Das Werk einschließlich aller seiner Teile ist urheberrechtlich geschützt. Jede

--- a/docs/audit_method/src/conf.py
+++ b/docs/audit_method/src/conf.py
@@ -28,6 +28,7 @@ author = 'Rohde & Schwarz'
 # The full version, including alpha/beta/rc tags
 release = auditinfo.botan_version()
 
+rst_prolog = auditinfo.rst_substitutions()
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/audit_report/src/00_00_preface.rst
+++ b/docs/audit_report/src/00_00_preface.rst
@@ -26,6 +26,10 @@ audit target revision to establish a new audited revision.
 | Andreas Seelos-Zankl (ASZ), Fraunhofer AISEC
 | Alexander Wagner (AW), Fraunhofer AISEC
 
+**Document Revision**
+
+This document was generated on |document_datestamp| based on the git revision |document_gitsha_short|.
+
 **Copyright**
 
 This work is protected by copyright law. Every application outside of copyright

--- a/docs/audit_report/src/00_09_introduction.rst
+++ b/docs/audit_report/src/00_09_introduction.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 This audit report summarizes the review results of changes to the Botan library code
-base between the tagged releases 3.1.1 and 3.2.0.
+base between the tagged releases |botan_git_base_ref| and |botan_version|.
 They were examined by considering the BSI technical guidelines' recommendations.
 In the meantime, the development of Botan continues, e.g., new algorithms are added, or bugs are fixed.
 Rohde & Schwarz Cybersecurity is part of this maintenance process as a contractor for this project.
@@ -13,9 +13,9 @@ audit report prepared by the contractor and submitted to the BSI with the source
 This examination applies, in particular, to cryptography-related changes. The BSI needs a well-founded decision
 basis for recommending a new Botan version. [PRM]_ describes the audit method that differs from the previous one.
 
-This document contains the audit report of the changes between the Botan versions 3.1.1 and
-3.2.0. Evaluated are the changes to relevant parts of the source code, the results of the side-channel
-analysis for Botan 3.2.0, and a list of updated documents.
+This document contains the audit report of the changes between the Botan versions |botan_git_base_ref| and
+|botan_version|. Evaluated are the changes to relevant parts of the source code, the results of the side-channel
+analysis for Botan |botan_version|, and a list of updated documents.
 
 
 Review Method

--- a/docs/audit_report/src/05_summary.rst
+++ b/docs/audit_report/src/05_summary.rst
@@ -1,8 +1,8 @@
 Summary and Results
 ===================
 
-This document contains the audit report for the changes between Botan version 3.1.1 and version
-3.2.0. The performed analysis includes a patch-based, manual audit of Botan's source code and
+This document contains the audit report for the changes between Botan version |botan_git_base_ref| and version
+|botan_version|. The performed analysis includes a patch-based, manual audit of Botan's source code and
 the results of several analysis tools.
 
 The most significant changes include the following:
@@ -11,7 +11,7 @@ The most significant changes include the following:
 
    Add a short list of the most significant changes
 
-According to the observations of this audit, Botan version 3.2.0 keeps the security level of
+According to the observations of this audit, Botan version |botan_version| keeps the security level of
 the previously reviewed version and complements the old version with various sensible and
 high-quality features.
 

--- a/docs/audit_report/src/conf.py
+++ b/docs/audit_report/src/conf.py
@@ -28,6 +28,7 @@ author = 'Rohde & Schwarz'
 # The full version, including alpha/beta/rc tags
 release = auditinfo.botan_version()
 
+rst_prolog = auditinfo.rst_substitutions()
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/cryptodoc/src/00_00_preface.rst
+++ b/docs/cryptodoc/src/00_00_preface.rst
@@ -26,6 +26,10 @@ This document describes the cryptographic implementations of Botan.
 | Amos Treiber (AT)
 | Fabian Albert (FA)
 
+**Document Revision**
+
+This document was generated on |document_datestamp| based on the git revision |document_gitsha_short|.
+
 **Copyright**
 
 This work is protected by copyright law. Every application outside of

--- a/docs/cryptodoc/src/conf.py
+++ b/docs/cryptodoc/src/conf.py
@@ -27,6 +27,7 @@ author = 'Rohde & Schwarz'
 # The full version, including alpha/beta/rc tags
 release = auditinfo.botan_version()
 
+rst_prolog = auditinfo.rst_substitutions()
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/testspec/src/00_00_preface.rst
+++ b/docs/testspec/src/00_00_preface.rst
@@ -24,6 +24,10 @@ This document specifies test cases implemented in the library's test suite.
 | René Meusel (RM), Rohde & Schwarz Cybersecurity
 | Fabian Albert (FA), Rohde & Schwarz Cybersecurity
 
+**Document Revision**
+
+This document was generated on |document_datestamp| based on the git revision |document_gitsha_short|.
+
 **Copyright**
 
 This work is protected by copyright law. Every application outside of copyright

--- a/docs/testspec/src/conf.py
+++ b/docs/testspec/src/conf.py
@@ -28,6 +28,7 @@ author = 'Rohde & Schwarz'
 # The full version, including alpha/beta/rc tags
 release = auditinfo.botan_version()
 
+rst_prolog = auditinfo.rst_substitutions()
 
 # -- General configuration ---------------------------------------------------
 

--- a/tools/auditinfo/auditinfo/__init__.py
+++ b/tools/auditinfo/auditinfo/__init__.py
@@ -1,2 +1,3 @@
 from auditinfo.botan import *
 from auditinfo.base import *
+from auditinfo.document import *

--- a/tools/auditinfo/auditinfo/base.py
+++ b/tools/auditinfo/auditinfo/base.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 def repository_root() -> str:
     """ The absolute root path of this git repository """
@@ -9,3 +10,12 @@ def repository_root() -> str:
             raise RuntimeError(f"base.py resides in an unexpected location: {__file__}")
         this_path = os.path.dirname(this_path)
     return this_path
+
+def repository_gitsha() -> str:
+    p = subprocess.Popen(["git", "rev-parse", "HEAD"], cwd=repository_root(),
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    errcode = p.wait()
+    if stderr or errcode != 0:
+        raise RuntimeError(f"Failed to find git revision:\n{stderr}")
+    return stdout.decode("utf-8")

--- a/tools/auditinfo/auditinfo/document.py
+++ b/tools/auditinfo/auditinfo/document.py
@@ -1,0 +1,25 @@
+import time
+
+from collections.abc import Mapping
+
+from auditinfo.base import *
+from auditinfo.botan import *
+
+def rst_substitutions(custom_substitutions : Mapping[str, str] = {}) -> str:
+    """ An rST prolog containing a number of useful substitutions.
+
+        Example: In rST, just write |document_gitsha| to render the
+                 current git revision of repository.
+    """
+
+    substitutions = {
+        "document_gitsha": repository_gitsha(),
+        "document_gitsha_short": repository_gitsha()[:7],
+        "document_datestamp": time.strftime("%d.%m.%Y"),
+        "botan_version": botan_version(),
+        "botan_git_base_ref": botan_git_base_ref(),
+        "botan_git_ref": botan_git_ref(),
+        **custom_substitutions
+    }
+
+    return '\n'.join([f".. |{subst}| replace:: {value}" for subst, value in substitutions.items()])


### PR DESCRIPTION
This adds a few global substitutions that are accessible in the reStructuredText sections of the documentation. Additionally, individual documents may define custom substitutions in their `conf.py`.

To use those in rST, simply type them inside pipe symbols as seen below. Note however, that substitutions will work in normal floating text only. Not inside code blocks!

```rst
This document was generated based on |document_gitsha_short| and targets |botan_version|.
```

Currently available substitutions:

| Substitution variable      | The generated value                                                                                                      |
| -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| `document_gitsha`          | The underlying git revision of sehlen/botan-docs                                                                         |
| `document_gitsha_short`    | Same as `document_gitsha` but truncated to 7 characters                                                                  |
| `document_datestamp`       | The current date (dd.mm.yyyy) as a generation date stamp                                                                 |
| `botan_version`            | The targeted Botan version of those documents (typically a human-readable string)                                        |
| `botan_git_base_ref`       | The base revision of this audit cycle (typically the last-reviewed version)                                              |
| `botan_git_ref`            | The final revision of this audit cycle (this might be a bare git sha when the target Botan version was not yet minted).  |
