### PR TITLE
Chore: More Specific Document File Names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         element:
-          - {name: Crypto Documentation, dir: docs/cryptodoc, out_name: crypto}
+          - {name: Crypto Documentation, dir: docs/cryptodoc, out_name: cryptodoc}
           - {name: Audit Method Description, dir: docs/audit_method, out_name: audit_method}
           - {name: Test Specification, dir: docs/testspec, out_name: testspec}
           - {name: Architecture Overview, dir: docs/architecture, out_name: architecture}
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Botan ${{ env.BOTAN_VERSION }} ${{ matrix.element.name }}
-          path: ${{ matrix.element.dir }}/_build/latex/${{ matrix.element.out_name }}.pdf
+          path: ${{ matrix.element.dir }}/_build/latex/${{ matrix.element.out_name }}-*.pdf
 
   url_check:
     strategy:

--- a/docs/architecture/src/conf.py
+++ b/docs/architecture/src/conf.py
@@ -76,7 +76,7 @@ html_theme = 'alabaster'
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class], toctree_only).
 latex_documents = [
-    (root_doc, 'architecture.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
+    (root_doc, f'architecture-botan-{auditinfo.botan_version()}.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
 ]
 
 latex_additional_files = [

--- a/docs/audit_method/src/conf.py
+++ b/docs/audit_method/src/conf.py
@@ -75,7 +75,7 @@ html_theme = 'alabaster'
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class], toctree_only).
 latex_documents = [
-    (root_doc, 'audit_method.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
+    (root_doc, f'audit_method-botan-{auditinfo.botan_version()}.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
 ]
 
 latex_additional_files = [

--- a/docs/audit_report/src/conf.py
+++ b/docs/audit_report/src/conf.py
@@ -75,7 +75,7 @@ html_theme = 'alabaster'
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class], toctree_only).
 latex_documents = [
-    (root_doc, 'audit_report.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
+    (root_doc, f'audit_report-botan-{auditinfo.botan_version()}.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
 ]
 
 latex_additional_files = [

--- a/docs/cryptodoc/src/conf.py
+++ b/docs/cryptodoc/src/conf.py
@@ -74,7 +74,7 @@ html_theme = 'alabaster'
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class], toctree_only).
 latex_documents = [
-    (root_doc, 'crypto.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
+    (root_doc, f'cryptodoc-botan-{auditinfo.botan_version()}.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
 ]
 
 latex_additional_files = [

--- a/docs/testspec/src/conf.py
+++ b/docs/testspec/src/conf.py
@@ -75,7 +75,7 @@ html_theme = 'alabaster'
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class], toctree_only).
 latex_documents = [
-    (root_doc, 'testspec.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
+    (root_doc, f'testspec-botan-{auditinfo.botan_version()}.tex', unicode_to_latex(project), unicode_to_latex(author), 'manual', False),
 ]
 
 latex_additional_files = [


### PR DESCRIPTION
File names are now: `{docname}-botan-{botan_target_version}.pdf`. Where `docname` is "cryptodoc", "audit_report", etc. and `botan_target_version` is the final version of the current audit iteration.