### PR TITLE
Audit: Kuznyechik

### DIFF
--- a/docs/audit_report/changes/topics/kuznyechik.yml
+++ b/docs/audit_report/changes/topics/kuznyechik.yml
@@ -1,11 +1,25 @@
 title: Kyznyechik
 
+classification: out of scope
+
+description: |
+  Kuznyechik (Russian: literally "grasshopper") is a block cipher
+  defined in the National Standard of the Russian Federation GOST R 34.12-2015.
+  It was discovered that its supposedly random S-boxes feature a mathematical
+  structure that is unlikely to have occured by chance [BirPerUdo16]_. It was accepted into
+  Botan because VeraCrypt supports it as an alternative cipher.
+
+  The BSI build policy prohibits the inclusion of Kuznyechik and no parts of it
+  will be compiled into the library's binary files.
+
 patches:
 # Kuznyechik block cipher  (@huven)
 - pr: 3680  # https://github.com/randombit/botan/pull/3680
   merge_commit: 4ec8531e169d1241b1ab6731a2d7eebd25b02d49
-  classification: unspecified
+  classification: out of scope
+  auditer: reneme
 
 # Update policies and docs for Kuznyechik addition  (@Jack Lloyd)
 - commit: be263bab07288a54576c3e25bd3383fe9abad8fa  # https://github.com/randombit/botan/commit/be263bab07288a54576c3e25bd3383fe9abad8fa
-  classification: unspecified
+  classification: info
+  auditer: reneme

--- a/docs/audit_report/src/06_bibliography.rst
+++ b/docs/audit_report/src/06_bibliography.rst
@@ -30,6 +30,10 @@
    Botan Test Report",
    Release TBD
 
+.. [BirPerUdo16] Alex Biryukov, Léo Perrin, Aleksei Udovenko
+   "Reverse-Engineering the S-Box of Streebog, Kuznyechik and STRIBOBr1"
+   Cryptology ePrint Archive, Paper 2016/071
+
 .. [BOTAN_GIT_300] https://github.com/randombit/botan/tree/3.0.0
 
 .. [BOTAN_GIT_311] https://github.com/randombit/botan/tree/3.1.1


### PR DESCRIPTION
For the record: Kuznyechik is explicitly prohibited in the BSI build policy and won't be compiled into the library when configured with that policy.

It is a National Standard of the Russian Federation and has [a questionable mathematical structure](https://eprint.iacr.org/2016/071) in its supposedly random S-boxes.