### PR TITLE
CI: Auto-update Audit Document based on upstream patches

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,65 @@
+name: Audit Auto-update
+
+on:
+  schedule:
+    # runs every day at 3:23 AM UTC
+    - cron:  '23 3 * * *'
+
+jobs:
+  audit_update:
+    name: "Auto-Update Audit Patches"
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    runs-on: ubuntu-22.04
+
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/source/tools/auditupdate
+
+    steps:
+      - name: Fetch Audit Repository
+        uses: actions/checkout@v3
+        with:
+          path: ./source
+          fetch-depth: 0
+
+      - name: Setup Environment Configuration
+        uses: ./source/.github/actions/setup-environment
+        with:
+          env_file: ./source/config/botan.env
+
+      - name: Fetch Botan Repository
+        uses: actions/checkout@v3
+        with:
+          path: ./botan
+          repository: ${{ env.BOTAN_REPO }}
+          fetch-depth: 0
+
+      - name: Handle the Audit Generator Cache
+        uses: actions/cache@v3
+        with:
+          path: ./auditupdate_cache
+          key: auditupdate_3.1-${{ github.run_id }}
+          restore-keys: auditupdate_3.1
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -qq install python3-poetry
+          poetry install --no-dev
+
+      - name: Set Committer Identity
+        run: |
+          git config user.name "Audit Update Bot"
+          git config user.email "actions@github.com"
+
+      - name: Check for Patches
+        run: poetry run python3 -m auditupdate.cli ${{ github.workspace }}/source/docs/audit_report/changes
+        env:
+          AUDIT_CACHE_LOCATION: ${{ github.workspace }}/auditupdate_cache
+          AUDIT_REPO_LOCATION: ${{ github.workspace }}/botan
+          BASIC_GH_TOKEN: ${{ github.token }}
+

--- a/tools/auditupdate/README.md
+++ b/tools/auditupdate/README.md
@@ -1,0 +1,12 @@
+# Auto-update Audit Patch References
+
+This allows tracking upstream patch updates automatically. As long as the
+current audit report document is not pinned to a specific target tag (i.e.
+`$BOTAN_REF` is set to a concrete commit SHA on the upstream main branch),
+this will check the upstream repository for newer patches.
+
+If the upstream repository received new patches, this will create a pull request
+on the documentation repository and add references to the those patches in the
+Audit Report document. A human auditor may then pull the auto-generated branch,
+audit and categorize the newly discovered patches and incorporate it into the
+document.

--- a/tools/auditupdate/auditupdate/cli.py
+++ b/tools/auditupdate/auditupdate/cli.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import sys
+import re
+import subprocess
+
+import github
+
+import auditinfo
+import genaudit
+import auditutils
+
+def run_git(cmd:list[str]) -> str:
+    return auditutils.run_git(cmd, auditinfo.repository_root())
+
+
+def get_autoupdate_pull_request(repo) -> github.PullRequest.PullRequest | None:
+    orguser = auditinfo.auditdoc_github_handle().split('/')[0]
+    branch = auditinfo.auditdoc_autoupdate_branch()
+    autoupdate_pr = list(repo.get_pulls(state="open", head=f"{orguser}:{branch}"))
+    return autoupdate_pr[0] if autoupdate_pr else None
+
+
+def target_git_ref_is_pinned():
+    """ We consider a target as 'not pinned' if it is set to a bare git SHA """
+    return re.match(r'^[0-9a-z]+$', auditinfo.botan_git_ref()) == None
+
+
+def update_uncategorized_patches(audit: genaudit.Audit, repo: genaudit.GitRepo, topic_file: str, topic_title: str) -> bool:
+    """ Finds unreferenced patches and updates the given topic YAML file accordingly """
+
+    unrefed_patches = genaudit.find_unreferenced_patches(audit, repo)
+    if not unrefed_patches:
+        return False
+
+    with open(audit.get_topic_file_path(topic_file), 'a', encoding="utf-8") as unrefed_topic:
+        if unrefed_topic.tell() == 0:
+            # if the file was just created, we have to add a preamble
+            unrefed_topic.write('\n'.join([
+                f"title: {topic_title}",
+                f"",
+                f"patches:",
+            ]))
+
+        # render all found unreferenced patches
+        rendered_unrefed_patches = ''.join([f"\n{patch.render_patch(repo, True)}\n" for patch in unrefed_patches])
+        unrefed_topic.write(rendered_unrefed_patches)
+
+    return True
+
+
+def create_pull_request(repo, branch):
+    title = ":robot: Audit: Auto-update with latest upstream patches"
+    description = '\n'.join([
+        f"This pull request was created automatically and contains the latest uncategorized patches from Botan's repository.",
+        f"",
+        f"Typically, you will need to pull this branch (`{branch}`) to categorize and audit the newly added patches. It is perfectly fine to push into this pull request and merge it after a code review.",
+        f"If not merged, this pull request will be updated with new patches continuously.",
+    ])
+    repo.create_pull(title=title, body=description, head=branch, base=auditinfo.auditdoc_main_branch())
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='This is a tool to generate audit reports based on GitHub information and YAML annotations.')
+    parser.add_argument('-t', '--token', help='GitHub access token (pulled from $BASIC_GH_TOKEN by default)',
+                        default=os.environ.get('BASIC_GH_TOKEN'))
+    parser.add_argument('-v', '--verbose', help='Enable detailed logging',
+                        default=False, action='store_true')
+    parser.add_argument('-c', '--cache-location',
+                        help='Path to a directory that should be used as disk cache (overrides config.yml and defaults to AUDIT_CACHE_LOCATION).',
+                        default=os.environ.get('AUDIT_CACHE_LOCATION'))
+    parser.add_argument('-r', '--repo-location',
+                        help='Path to a local checkout of the Botan repository (overrides config.yml and defaults to AUDIT_REPO_LOCATION).',
+                        default=os.environ.get('AUDIT_REPO_LOCATION'))
+    parser.add_argument('-o', '--output-topic',
+                        help='File name of the topic to append unreferenced patches to',
+                        default='uncategorized.yml')
+    parser.add_argument('-n', '--output-topic-title',
+                        help='Title of the topic to append unreferenced patches to',
+                        default='Uncategorized Patches')
+    parser.add_argument('audit_config_dir',
+                         help='the audit directory to be updated')
+
+    args = parser.parse_args(sys.argv[1:])
+
+    loglevel = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=loglevel)
+
+    # Auto-updater is disabled if $BOTAN_REF is set to something that does not
+    # resemble a git SHA (e.g. a git tag like 3.2.0).
+    if target_git_ref_is_pinned():
+        logging.info(f"No update necessary, target is pinned to: {auditinfo.botan_git_ref()}")
+        return 0
+
+    # Figure out whether we're updating an existing Auto-update Pull Request
+    # or have to create a new one.
+    old_target = auditinfo.botan_git_ref()
+    gh = github.Github(auth=github.Auth.Token(args.token))
+    docrepo = gh.get_repo(auditinfo.auditdoc_github_handle())
+    pr = get_autoupdate_pull_request(docrepo)
+    if pr:
+        logging.info(f"Found open auto-update Pull Request (#{pr.number}), switching branch...")
+        run_git(["checkout", auditinfo.auditdoc_autoupdate_branch()])
+    else:
+        logging.info(f"Did not find an open auto-update Pull Request, creating a branch...")
+        run_git(["checkout", "-B", auditinfo.auditdoc_autoupdate_branch()])
+
+    # Check whether new patches have landed in Botan upstream
+    # (potentially compared to a currently-open Auto-update pull request)
+    _, repo = genaudit.init_from_command_line_arguments(args)
+    new_target = repo.tip_of_main_branch().sha
+    if new_target == auditinfo.botan_git_ref():
+        logging.info(f"No update necessary, target is pointing to latest commit: {auditinfo.botan_git_ref()}")
+        return 0
+
+    # Update the botan.env configuration file with the new upstream target revision.
+    auditinfo.update_botan_git_ref(new_target)
+    run_git(["add", auditinfo.config_file_path()])
+
+    # Re-initialize the Audit Generator scripts with the just-updated target revision
+    # and determine which patches need to be added to the audit report document.
+    audit, repo = genaudit.init_from_command_line_arguments(args)
+    found_patches = update_uncategorized_patches(audit, repo, args.output_topic, args.output_topic_title)
+    if not found_patches:
+        logging.critical(f"Upstream repo was updated (from {old_target[0:7]} to {new_target[0:7]}) but didn't find new patches. Something is wrong here!")
+        return 1
+
+    # Commit and push the new (uncategorized) patch references.
+    run_git(["add", audit.get_topic_file_path(args.output_topic)])
+    run_git(["commit", "--no-gpg-sign", "-m", f"Automatic update to match patches until {new_target[0:7]}"])
+    run_git(["push", "--set-upstream", "origin", auditinfo.auditdoc_autoupdate_branch()])
+
+    # If we're not updating an existing Auto-update Pull Request, we need to
+    # create a new one.
+    if not pr:
+        logging.info(f"creating Auto-Update pull request...")
+        create_pull_request(docrepo, auditinfo.auditdoc_autoupdate_branch())
+
+    # Profit!
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/auditupdate/poetry.lock
+++ b/tools/auditupdate/poetry.lock
@@ -1,0 +1,265 @@
+[[package]]
+name = "auditinfo"
+version = "0.1.0"
+description = "Central information retrieval of this audit project"
+category = "main"
+optional = false
+python-versions = "^3.10"
+develop = true
+
+[package.source]
+type = "directory"
+url = "../auditinfo"
+
+[[package]]
+name = "auditutils"
+version = "0.1.0"
+description = "Basic helpers for audit generation"
+category = "main"
+optional = false
+python-versions = "^3.10"
+develop = true
+
+[package.source]
+type = "directory"
+url = "../auditutils"
+
+[[package]]
+name = "certifi"
+version = "2023.7.22"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "cffi"
+version = "1.15.1"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "3.2.0"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[[package]]
+name = "cryptography"
+version = "41.0.4"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+cffi = ">=1.12"
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+nox = ["nox"]
+pep8test = ["black", "ruff", "mypy", "check-sdist"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist", "pretend"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "deprecated"
+version = "1.2.14"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["tox", "pytest", "pytest-cov", "bump2version (<1)", "sphinx (<2)"]
+
+[[package]]
+name = "genaudit"
+version = "0.1.0"
+description = "Generator scripts and helpers to pull patch information from GitHub"
+category = "main"
+optional = false
+python-versions = "^3.10"
+develop = true
+
+[package.dependencies]
+auditinfo = {path = "../auditinfo", develop = true}
+auditutils = {path = "../auditutils", develop = true}
+Jinja2 = "^3.0"
+pygithub = "~1.59"
+pyyaml = "^6.0"
+
+[package.source]
+type = "directory"
+url = "../genaudit"
+
+[[package]]
+name = "idna"
+version = "3.4"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "jinja2"
+version = "3.1.2"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "markupsafe"
+version = "2.1.3"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pygithub"
+version = "1.59.1"
+description = "Use the full Github API v3"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+deprecated = "*"
+pyjwt = {version = ">=2.4.0", extras = ["crypto"]}
+pynacl = ">=1.4.0"
+requests = ">=2.14.0"
+
+[[package]]
+name = "pyjwt"
+version = "2.8.0"
+description = "JSON Web Token implementation in Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.4.0)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "pre-commit"]
+docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
+tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
+
+[[package]]
+name = "pynacl"
+version = "1.5.0"
+description = "Python binding to the Networking and Cryptography (NaCl) library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = ">=1.4.1"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+tests = ["pytest (>=3.2.1,!=3.3.0)", "hypothesis (>=3.27.0)"]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<3"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "urllib3"
+version = "2.0.5"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "wrapt"
+version = "1.15.0"
+description = "Module for decorators, wrappers and monkey patching."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.10"
+content-hash = "ee86a04973532eeaf1adf383f16dd7a46ee0ab7afae645894f663ad0760d5e82"
+
+[metadata.files]
+auditinfo = []
+auditutils = []
+certifi = []
+cffi = []
+charset-normalizer = []
+cryptography = []
+deprecated = []
+genaudit = []
+idna = []
+jinja2 = []
+markupsafe = []
+pycparser = []
+pygithub = []
+pyjwt = []
+pynacl = []
+pyyaml = []
+requests = []
+urllib3 = []
+wrapt = []

--- a/tools/auditupdate/pyproject.toml
+++ b/tools/auditupdate/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "auditupdate"
+version = "0.1.0"
+description = "Gather information about unaudited upstream patches"
+authors = ["René Meusel <rene.meusel@rohde-schwarz.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+
+pygithub = "~1.59"
+pyyaml = "^6.0"
+Jinja2 = "^3.0"
+
+auditinfo = { path = "../auditinfo", develop = true }
+genaudit = { path = "../genaudit", develop = true }
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### Pull Request Dependencies

* https://github.com/sehlen-bsi/botan-docs/pull/134

### Description

This registers an auto-update job that runs every night and checks the upstream Botan repository for new patches. As long as the current audit target is not pinned to a specific Botan version (i.e. `$BOTAN_REF` points to a commit SHA rather than a tag), this will automatically try to update the document with new patches.

If new patches are found, a pull request is opened, that contains references to those patches in the "uncategorized" topic. A human auditor can then manually categorize them and update the pull request with their Audit result.

Note that the auto-updater recognizes when an auto-update pull request is currently open and amend it as necessary.