### PR TITLE
FIX: add some missing modules

### DIFF
--- a/docs/audit_report/src/00_09_introduction.rst
+++ b/docs/audit_report/src/00_09_introduction.rst
@@ -54,11 +54,12 @@ components. For the library implementation itself (``src/lib``), all modules
 that are *required* or *available* in the BSI build policy and their
 dependencies are in the scope of this document. Additionally, we review the
 following modules and its dependencies: ``certstor_flatfile``,
+``certstor_sqlite3``, ``certstor_system_macos``, ``certstor_system_windows``,
 ``certstor_system``, ``dilithium_aes``, ``dilithium``, ``ffi``, ``kyber_90s``,
-``kyber``, ``pkcs11``, ``shake``, ``sphincsplus_sha2``, ``sphincsplus_shake``,
-``tls_cbc``, ``tls12``, ``tls13_pqc``, ``tls13``, ``xts``. Patches that don't
-alter any of the above-mentioned components or relevant modules are considered
-out-of-scope.
+``kyber``, ``pkcs11``, ``sha1_armv8``, ``sha1_sse2``, ``sha1_x86``, ``shake``,
+``sphincsplus_sha2``, ``sphincsplus_shake``, ``tls_cbc``, ``tls12``,
+``tls13_pqc``, ``tls13``, ``xts``. Patches that don't alter any of the
+above-mentioned components or relevant modules are considered out-of-scope.
 
 Below is the full list of modules (from ``src/lib``) whose changes were
 reviewed:


### PR DESCRIPTION
* `certstor_system_macos`
* `certstor_system_windows`
* `certstor_sqlite3`
* `sha1_armv8`
* `sha1_sse2`
* `sha1_x86`