### PR TITLE
Introduce BOTAN_UPSTREAM_REPO config

### DIFF
--- a/config/botan.env
+++ b/config/botan.env
@@ -1,7 +1,14 @@
-# The GitHub reference of the Botan target repository.
+# The GitHub reference of the upstream Botan repository.
+# API requests for meta information and pull requests are targeted here.
+BOTAN_UPSTREAM_REPO=randombit/botan
+
+# The GitHub reference of the Botan target repository
+# This is typically equal to BOTAN_UPSTREAM_REPO, except if we need to refer to
+# unmerged changes that divert from the upstream repository. Links in the
+# documents will refer to this repository.
 BOTAN_REPO=randombit/botan
 
-# The name of Botan's main branch
+# The name of Botan's main branch on the BOTAN_RPEO
 BOTAN_MAIN_BRANCH=master
 
 # The version of Botan that is currently being targeted by this documentation.

--- a/tools/auditinfo/auditinfo/botan.py
+++ b/tools/auditinfo/auditinfo/botan.py
@@ -43,6 +43,10 @@ def botan_github_handle() -> str:
     """ The repository handle of the main code base on GitHub """
     return __get_from_config("BOTAN_REPO")
 
+def botan_upstream_github_handle() -> str:
+    """ The repository handle of the upstream code base on GitHub """
+    return __get_from_config("BOTAN_UPSTREAM_REPO")
+
 def botan_main_branch() -> str:
     """ The name of the main branch of the main code base on GitHub """
     return __get_from_config("BOTAN_MAIN_BRANCH")

--- a/tools/genaudit/genaudit/audit.py
+++ b/tools/genaudit/genaudit/audit.py
@@ -34,7 +34,7 @@ class Audit:
 
         util.check_keys("Repo", cfg['repo'].keys(), ['local_checkout'])
 
-        self.github_handle = auditinfo.botan_github_handle()
+        self.github_handle = auditinfo.botan_upstream_github_handle()
         self.main_branch = auditinfo.botan_main_branch()
         self.local_checkout = cfg['repo']['local_checkout']
         self.git_ref_from = auditinfo.botan_git_base_ref()


### PR DESCRIPTION
This allows building documents based on a patch-set that is not hosted on the Botan upstream repository. Use this, when you need to reference unmerged patches and adaptions. The GitHub API requests are directed towards BOTAN_UPSTREAM_REPO.