### PR TITLE
FIX: document-internal reference

### DIFF
--- a/docs/audit_report/changes/topics/chores_sensitive.yml
+++ b/docs/audit_report/changes/topics/chores_sensitive.yml
@@ -1,9 +1,9 @@
 title: Code Improvements on Sensitive Code
 
 description: |
-  Similarly to :ref:`chores`, this contains generic improvements to the code
-  base. However, these changes significantly modify code that is directly
-  relevant for the security of the library.
+  Similarly to :ref:`changes/chores`, this contains generic improvements to
+  the code base. However, these changes significantly modify code that is
+  directly relevant for the security of the library.
 
   Most notably, this replaces legacy buffer handling with more modern helper
   constructions to improve readability and general memory safety.


### PR DESCRIPTION
References between topics are possible by simply specifying the topic's YAML file name (without file extension). But I didn't recall that one has to add the `changes` parent directory.

Admittedly, CI should catch things like that! Looking into it tmrw.