### PR TITLE
Abort Sphinx build on warnings

### DIFF
--- a/docs/architecture/Makefile
+++ b/docs/architecture/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = src
 BUILDDIR      = _build

--- a/docs/audit_method/Makefile
+++ b/docs/audit_method/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = src
 BUILDDIR      = _build

--- a/docs/audit_report/Makefile
+++ b/docs/audit_report/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = src
 CHANGESDIR    = changes

--- a/docs/cryptodoc/Makefile
+++ b/docs/cryptodoc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = src
 BUILDDIR      = _build

--- a/docs/testreport/Makefile
+++ b/docs/testreport/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = src
 SCRIPTDIR     = scripts

--- a/docs/testspec/Makefile
+++ b/docs/testspec/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = src
 BUILDDIR      = _build


### PR DESCRIPTION
`-W` is "treat sphinx warnings as errors". For instance, a reference that cannot be resolved is a warning and won't fail the build, otherwise. Locally, the PDF generator produces so much terminal-barf that warnings are often overlooked, despite being rendered in a different color.

`--keep-going` doesn't immediately stop on the first error. That is useful in CI, because it shows all the broken things to be fixed. Hopefully, that makes the "fix, commit, push, CI-fail"-cycle shorter.

Side note: CI now fails because the underlying `main` branch currently produces a warning that is fixed in #164.