### PR TITLE
CI: Check Patch Audit Compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,14 @@ jobs:
           AUDIT_REPO_LOCATION: ${{ github.workspace }}/botan
           BASIC_GH_TOKEN: ${{ github.token }}
 
+      - name: Check Patch Audit Status
+        working-directory: source/docs/audit_report
+        run: poetry run python3 -m genaudit.cli verify_audits changes
+        env:
+          AUDIT_CACHE_LOCATION: ${{ github.workspace }}/audit_generator_cache
+          AUDIT_REPO_LOCATION: ${{ github.workspace }}/botan
+          BASIC_GH_TOKEN: ${{ github.token }}
+
       - name: Build Document
         working-directory: source/docs/audit_report
         run: poetry run make latexpdf

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Weiterentwicklung der Kryptobibliothek Botan".
 
 This monorepo contains documents (in `/docs`) as well as auxiliary helper
 scripts (in `/tools`) and some common resources (in `/resources`). The monorepo
-is configured in a global configuration file (in `/config/botan.env`). Internal
+is configured in a global configuration directory (in `/config`). Internal
 documentation and checklists are located in `/internal`.
 
 Most documents come with a `Makefile` to build them as PDF, HTML or other

--- a/config/auditors.yml
+++ b/config/auditors.yml
@@ -1,0 +1,15 @@
+# This file contains the list of auditors along with their GitHub handles.
+# Authorship, approval or auditor-annotation of patches in the Audit Report
+# document are considered to be authorative in the CI.
+
+auditors:
+  - name: Fabian Albert
+    github: FAlbertDev
+  - name: René Fischer
+    github: securitykernel
+  - name: Philippe Lieser
+    github: lieser
+  - name: René Meusel
+    github: reneme
+  - name: Amos Treiber
+    github: atreiber94

--- a/docs/architecture/poetry.lock
+++ b/docs/architecture/poetry.lock
@@ -30,13 +30,16 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../../tools/auditinfo"
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -47,7 +50,7 @@ dev = ["pytest (>=6.0)", "pytest-cov", "freezegun (>=1.0,<2.0)"]
 
 [[package]]
 name = "cattrs"
-version = "23.2.1"
+version = "23.2.3"
 description = "Composable complex class support for attrs and dataclasses."
 category = "dev"
 optional = false
@@ -101,7 +104,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "esbonio"
-version = "0.16.2"
+version = "0.16.3"
 description = "A Language Server for Sphinx projects."
 category = "dev"
 optional = false
@@ -120,7 +123,7 @@ typecheck = ["mypy", "pytest-lsp (>=0.3.1)", "types-appdirs", "types-docutils", 
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.3"
+version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -131,7 +134,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -189,11 +192,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.24)", "sphinx (>=7.1.1)"]
@@ -201,7 +204,7 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest-cov (>=4.1)", "pytes
 
 [[package]]
 name = "pygls"
-version = "1.2.0"
+version = "1.2.1"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 category = "dev"
 optional = false
@@ -215,7 +218,7 @@ ws = ["websockets (>=11.0.3,<12.0.0)"]
 
 [[package]]
 name = "pygments"
-version = "2.17.1"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -238,6 +241,14 @@ name = "pyspellchecker"
 version = "0.7.2"
 description = "Pure python spell checker based on work by Peter Norvig"
 category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -404,7 +415,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false
@@ -451,6 +462,7 @@ pygls = []
 pygments = []
 pylatexenc = []
 pyspellchecker = []
+pyyaml = []
 requests = []
 snowballstemmer = []
 sourceref = []

--- a/docs/audit_method/poetry.lock
+++ b/docs/audit_method/poetry.lock
@@ -30,13 +30,16 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../../tools/auditinfo"
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -47,7 +50,7 @@ dev = ["pytest (>=6.0)", "pytest-cov", "freezegun (>=1.0,<2.0)"]
 
 [[package]]
 name = "cattrs"
-version = "23.2.1"
+version = "23.2.3"
 description = "Composable complex class support for attrs and dataclasses."
 category = "dev"
 optional = false
@@ -101,7 +104,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "esbonio"
-version = "0.16.2"
+version = "0.16.3"
 description = "A Language Server for Sphinx projects."
 category = "dev"
 optional = false
@@ -120,7 +123,7 @@ typecheck = ["mypy", "pytest-lsp (>=0.3.1)", "types-appdirs", "types-docutils", 
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.3"
+version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -131,7 +134,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -189,11 +192,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.24)", "sphinx (>=7.1.1)"]
@@ -201,7 +204,7 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest-cov (>=4.1)", "pytes
 
 [[package]]
 name = "pygls"
-version = "1.2.0"
+version = "1.2.1"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 category = "dev"
 optional = false
@@ -215,7 +218,7 @@ ws = ["websockets (>=11.0.3,<12.0.0)"]
 
 [[package]]
 name = "pygments"
-version = "2.17.1"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -238,6 +241,14 @@ name = "pyspellchecker"
 version = "0.7.2"
 description = "Pure python spell checker based on work by Peter Norvig"
 category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -404,7 +415,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false
@@ -451,6 +462,7 @@ pygls = []
 pygments = []
 pylatexenc = []
 pyspellchecker = []
+pyyaml = []
 requests = []
 snowballstemmer = []
 sourceref = []

--- a/docs/audit_report/changes/topics/chores.yml
+++ b/docs/audit_report/changes/topics/chores.yml
@@ -41,6 +41,7 @@ patches:
 # Don't inline Null_RNG::fill_bytes_with_input  (Jack Lloyd)
 - commit: 723fa3a260b9be10a96223c71c2b8f44631a1c5e  # https://github.com/randombit/botan/commit/723fa3a260b9be10a96223c71c2b8f44631a1c5e
   classification: info
+  auditer: reneme
 
 # Remove abort call accidentally left over from debugging  (Jack Lloyd)
 - commit: 6117553c9d7652aaa050ac931447ccdefa5f658f  # https://github.com/randombit/botan/commit/6117553c9d7652aaa050ac931447ccdefa5f658f

--- a/docs/audit_report/poetry.lock
+++ b/docs/audit_report/poetry.lock
@@ -30,6 +30,9 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../../tools/auditinfo"
@@ -49,7 +52,7 @@ url = "../../tools/auditutils"
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -60,7 +63,7 @@ dev = ["pytest (>=6.0)", "pytest-cov", "freezegun (>=1.0,<2.0)"]
 
 [[package]]
 name = "cattrs"
-version = "23.2.1"
+version = "23.2.3"
 description = "Composable complex class support for attrs and dataclasses."
 category = "dev"
 optional = false
@@ -117,7 +120,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "cryptography"
-version = "41.0.5"
+version = "41.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -160,7 +163,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "esbonio"
-version = "0.16.2"
+version = "0.16.3"
 description = "A Language Server for Sphinx projects."
 category = "dev"
 optional = false
@@ -179,7 +182,7 @@ typecheck = ["mypy", "pytest-lsp (>=0.3.1)", "types-appdirs", "types-docutils", 
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.3"
+version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -210,7 +213,7 @@ url = "../../tools/genaudit"
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -268,11 +271,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.24)", "sphinx (>=7.1.1)"]
@@ -302,7 +305,7 @@ requests = ">=2.14.0"
 
 [[package]]
 name = "pygls"
-version = "1.2.0"
+version = "1.2.1"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 category = "dev"
 optional = false
@@ -316,7 +319,7 @@ ws = ["websockets (>=11.0.3,<12.0.0)"]
 
 [[package]]
 name = "pygments"
-version = "2.17.1"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -545,7 +548,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false

--- a/docs/audit_report/src/00_09_introduction.rst
+++ b/docs/audit_report/src/00_09_introduction.rst
@@ -261,10 +261,4 @@ in this document. The distinction between "approvers" (of pull requests on
 GitHub) and "auditors" (in retrospect, explicitly for this project) is visualized
 by setting the latter into parenthesis in the patch tables below.
 
-Auditing members of this project and their GitHub handles are:
-
-* Fabian Albert (@FAlbertDev)
-* René Fischer (@securitykernel)
-* Philippe Lieser (@lieser)
-* René Meusel (@reneme)
-* Amos Treiber (@atreiber94)
+Auditing members of this project and their GitHub handles are: |auditors_list|

--- a/docs/audit_report/src/conf.py
+++ b/docs/audit_report/src/conf.py
@@ -28,7 +28,9 @@ author = 'Rohde & Schwarz'
 # The full version, including alpha/beta/rc tags
 release = auditinfo.botan_version()
 
-rst_prolog = auditinfo.rst_substitutions()
+rst_prolog = auditinfo.rst_substitutions({
+    "auditors_list": ', '.join([f"**{a.name}** (@{a.github_handle})" for a in auditinfo.authorative_auditors()]),
+})
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/cryptodoc/poetry.lock
+++ b/docs/cryptodoc/poetry.lock
@@ -30,13 +30,16 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../../tools/auditinfo"
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -47,7 +50,7 @@ dev = ["pytest (>=6.0)", "pytest-cov", "freezegun (>=1.0,<2.0)"]
 
 [[package]]
 name = "cattrs"
-version = "23.2.1"
+version = "23.2.3"
 description = "Composable complex class support for attrs and dataclasses."
 category = "dev"
 optional = false
@@ -101,7 +104,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "esbonio"
-version = "0.16.2"
+version = "0.16.3"
 description = "A Language Server for Sphinx projects."
 category = "dev"
 optional = false
@@ -120,7 +123,7 @@ typecheck = ["mypy", "pytest-lsp (>=0.3.1)", "types-appdirs", "types-docutils", 
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.3"
+version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -131,7 +134,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -189,11 +192,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.24)", "sphinx (>=7.1.1)"]
@@ -201,7 +204,7 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest-cov (>=4.1)", "pytes
 
 [[package]]
 name = "pygls"
-version = "1.2.0"
+version = "1.2.1"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 category = "dev"
 optional = false
@@ -215,7 +218,7 @@ ws = ["websockets (>=11.0.3,<12.0.0)"]
 
 [[package]]
 name = "pygments"
-version = "2.17.1"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -238,6 +241,14 @@ name = "pyspellchecker"
 version = "0.7.2"
 description = "Pure python spell checker based on work by Peter Norvig"
 category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -404,7 +415,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false
@@ -451,6 +462,7 @@ pygls = []
 pygments = []
 pylatexenc = []
 pyspellchecker = []
+pyyaml = []
 requests = []
 snowballstemmer = []
 sourceref = []

--- a/docs/testreport/poetry.lock
+++ b/docs/testreport/poetry.lock
@@ -30,6 +30,9 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../../tools/auditinfo"
@@ -49,7 +52,7 @@ url = "../../tools/auditutils"
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -60,7 +63,7 @@ dev = ["pytest (>=6.0)", "pytest-cov", "freezegun (>=1.0,<2.0)"]
 
 [[package]]
 name = "cattrs"
-version = "23.2.1"
+version = "23.2.3"
 description = "Composable complex class support for attrs and dataclasses."
 category = "dev"
 optional = false
@@ -117,7 +120,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "cryptography"
-version = "41.0.5"
+version = "41.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -160,7 +163,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "esbonio"
-version = "0.16.2"
+version = "0.16.3"
 description = "A Language Server for Sphinx projects."
 category = "dev"
 optional = false
@@ -179,7 +182,7 @@ typecheck = ["mypy", "pytest-lsp (>=0.3.1)", "types-appdirs", "types-docutils", 
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.3"
+version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -218,7 +221,7 @@ url = "../../tools/genaudit"
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -287,11 +290,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.24)", "sphinx (>=7.1.1)"]
@@ -321,7 +324,7 @@ requests = ">=2.14.0"
 
 [[package]]
 name = "pygls"
-version = "1.2.0"
+version = "1.2.1"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 category = "dev"
 optional = false
@@ -335,7 +338,7 @@ ws = ["websockets (>=11.0.3,<12.0.0)"]
 
 [[package]]
 name = "pygments"
-version = "2.17.1"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -564,7 +567,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false

--- a/docs/testspec/poetry.lock
+++ b/docs/testspec/poetry.lock
@@ -30,13 +30,16 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../../tools/auditinfo"
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -47,7 +50,7 @@ dev = ["pytest (>=6.0)", "pytest-cov", "freezegun (>=1.0,<2.0)"]
 
 [[package]]
 name = "cattrs"
-version = "23.2.1"
+version = "23.2.3"
 description = "Composable complex class support for attrs and dataclasses."
 category = "dev"
 optional = false
@@ -101,7 +104,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "esbonio"
-version = "0.16.2"
+version = "0.16.3"
 description = "A Language Server for Sphinx projects."
 category = "dev"
 optional = false
@@ -120,7 +123,7 @@ typecheck = ["mypy", "pytest-lsp (>=0.3.1)", "types-appdirs", "types-docutils", 
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.3"
+version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -131,7 +134,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -189,11 +192,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.24)", "sphinx (>=7.1.1)"]
@@ -201,7 +204,7 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest-cov (>=4.1)", "pytes
 
 [[package]]
 name = "pygls"
-version = "1.2.0"
+version = "1.2.1"
 description = "A pythonic generic language server (pronounced like 'pie glass')"
 category = "dev"
 optional = false
@@ -215,7 +218,7 @@ ws = ["websockets (>=11.0.3,<12.0.0)"]
 
 [[package]]
 name = "pygments"
-version = "2.17.1"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -238,6 +241,14 @@ name = "pyspellchecker"
 version = "0.7.2"
 description = "Pure python spell checker based on work by Peter Norvig"
 category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -404,7 +415,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false
@@ -451,6 +462,7 @@ pygls = []
 pygments = []
 pylatexenc = []
 pyspellchecker = []
+pyyaml = []
 requests = []
 snowballstemmer = []
 sourceref = []

--- a/tools/auditinfo/auditinfo/__init__.py
+++ b/tools/auditinfo/auditinfo/__init__.py
@@ -1,3 +1,4 @@
 from auditinfo.botan import *
 from auditinfo.base import *
+from auditinfo.auditor import *
 from auditinfo.document import *

--- a/tools/auditinfo/auditinfo/auditor.py
+++ b/tools/auditinfo/auditinfo/auditor.py
@@ -1,0 +1,18 @@
+import yaml
+
+from auditinfo.botan import auditors_file_path
+
+class Auditor:
+    def __init__(self, name: str, github_handle: str):
+        self.name = name
+        self.github_handle = github_handle[1:] if github_handle.startswith('@') else github_handle
+
+def authorative_auditors() -> list[Auditor]:
+    auditors_file = auditors_file_path()
+    strm = open(auditors_file, 'r')
+    cfg = yaml.load(strm, Loader=yaml.FullLoader)
+    if not cfg:
+        raise RuntimeError("Failed to load auditor configuation: %s" % auditors_file)
+    return [Auditor(auditor['name'], auditor['github']) for auditor in cfg['auditors']]
+
+

--- a/tools/auditinfo/auditinfo/botan.py
+++ b/tools/auditinfo/auditinfo/botan.py
@@ -6,6 +6,9 @@ from auditinfo.base import repository_root
 def config_file_path() -> str:
     return os.path.join(repository_root(), "config", "botan.env")
 
+def auditors_file_path() -> str:
+    return os.path.join(repository_root(), "config", "auditors.yml")
+
 def __conf_var_pattern():
     return re.compile(r"(^[a-zA-Z_0-9]+)=(.+)\n$")
 

--- a/tools/auditinfo/poetry.lock
+++ b/tools/auditinfo/poetry.lock
@@ -1,8 +1,15 @@
-package = []
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "17ca553b0bb9298a6ed528dd21e544ca433179192dba32a9920168e1c199d74f"
+content-hash = "171b9d46ecf73d8671ffbdd4a6e5d8364c43bcf158c81c91c03d619b83006108"
 
 [metadata.files]
+pyyaml = []

--- a/tools/auditinfo/pyproject.toml
+++ b/tools/auditinfo/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["René Meusel <rene.meusel@rohde-schwarz.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
+pyyaml = "^6.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/tools/auditupdate/poetry.lock
+++ b/tools/auditupdate/poetry.lock
@@ -7,6 +7,9 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../auditinfo"
@@ -53,7 +56,7 @@ python-versions = ">=3.7.0"
 
 [[package]]
 name = "cryptography"
-version = "41.0.5"
+version = "41.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -108,7 +111,7 @@ url = "../genaudit"
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false

--- a/tools/genaudit/genaudit/__init__.py
+++ b/tools/genaudit/genaudit/__init__.py
@@ -2,6 +2,6 @@ from genaudit.audit import Audit
 from genaudit.repo import GitRepo
 from genaudit.topic import Topic
 from genaudit.render import Renderer
-from genaudit.verify import find_unreferenced_patches, find_misreferenced_pull_request_merges
+from genaudit.verify import find_unreferenced_patches, find_misreferenced_pull_request_merges, find_insufficiently_audited_patches
 from genaudit.base import init_from_command_line_arguments
 from genaudit.refs import *

--- a/tools/genaudit/genaudit/cli.py
+++ b/tools/genaudit/genaudit/cli.py
@@ -44,6 +44,16 @@ def find_unrefed(audit: genaudit.Audit, repo: genaudit.GitRepo, args: argparse.N
         return 0
 
 
+def verify_audits(audit: genaudit.Audit, repo: genaudit.GitRepo, args: argparse.Namespace):
+    insufficiently_audited_patches = genaudit.find_insufficiently_audited_patches(audit, repo)
+    logging.info("Found %d insufficiently audited patches", len(insufficiently_audited_patches))
+
+    for patch in insufficiently_audited_patches:
+        print(f"In topic '{patch[1]}', the patch '{patch[0]}' is not sufficiently audited, because: {patch[2]}")
+
+    return 0 if not insufficiently_audited_patches else 1
+
+
 def verify_merge_commits(audit: genaudit.Audit, repo: genaudit.GitRepo, args: argparse.Namespace):
     inconsistent_prs = genaudit.find_misreferenced_pull_request_merges(audit, repo)
     logging.info("Found %d Pull Requests with misreferenced commits", len(inconsistent_prs))
@@ -100,6 +110,12 @@ def main():
     unrefed.add_argument('audit_config_dir',
                          help='the audit directory to be used')
     unrefed.set_defaults(func=find_unrefed)
+
+    audit_checks = subparsers.add_parser(
+        'verify_audits', help='Find patches that are not sufficiently audited.')
+    audit_checks.add_argument('audit_config_dir',
+                         help='the audit directory to be used')
+    audit_checks.set_defaults(func=verify_audits)
 
     merge_commits = subparsers.add_parser(
         'verify_merges', help='Find pull requests that are not referenced with their respective merge commit hash')

--- a/tools/genaudit/genaudit/topic.py
+++ b/tools/genaudit/genaudit/topic.py
@@ -27,6 +27,9 @@ class Topic:
             logging.debug("Found %s topic '%s' with %d patch references",
                           self._classification, self.title, len(self.patches))
 
+    def __repr__(self):
+        return "%s" % self.title
+
     def _load_patches(self, cfg) -> list[refs.PullRequest|refs.Commit]:
         def load(patch):
             def get_ref():

--- a/tools/genaudit/poetry.lock
+++ b/tools/genaudit/poetry.lock
@@ -7,6 +7,9 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../auditinfo"
@@ -53,7 +56,7 @@ python-versions = ">=3.7.0"
 
 [[package]]
 name = "cryptography"
-version = "41.0.5"
+version = "41.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -88,7 +91,7 @@ dev = ["tox", "pytest", "pytest-cov", "bump2version (<1)", "sphinx (<2)"]
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false

--- a/tools/sourceref/poetry.lock
+++ b/tools/sourceref/poetry.lock
@@ -15,13 +15,16 @@ optional = false
 python-versions = "^3.10"
 develop = true
 
+[package.dependencies]
+pyyaml = "^6.0"
+
 [package.source]
 type = "directory"
 url = "../auditinfo"
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -64,7 +67,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -110,7 +113,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "pygments"
-version = "2.17.1"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
@@ -119,6 +122,14 @@ python-versions = ">=3.7"
 [package.extras]
 plugins = ["importlib-metadata"]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
@@ -295,6 +306,7 @@ jinja2 = []
 markupsafe = []
 packaging = []
 pygments = []
+pyyaml = []
 requests = []
 snowballstemmer = []
 sphinx = []


### PR DESCRIPTION
This adds an automated check to ensure that all referenced patches in the audit document are sufficiently denoted to assume that an audit was performed on it.

Note that I had to install `pyyaml` for `auditinfo`. Therefore, I needed to `poetry update` all downstream dependencies. Hence: sorry for the `poetry.lock` clutter in this PR.

Currently, this checks:

1. Is the patch authored, approved or audited by at least one authorative auditor, registered in config/auditors.yml
2. Is the patch classified regarding its relevance to the library's overall security

Note that we should not merge this until all currently registered patches are properly audited. Otherwise the `main` branch won't build anymore. As a side-effect this will also fail the Auto-Update pull request after the Bot created it. It will only turn green once an auditor clones it and performs an audit on the detected upstream patches.