### PR TITLE
Add genaudit.cli list_patches

### DIFF
--- a/tools/genaudit/genaudit/cli.py
+++ b/tools/genaudit/genaudit/cli.py
@@ -74,6 +74,16 @@ def verify_merge_commits(audit: genaudit.Audit, repo: genaudit.GitRepo, args: ar
     return 0 if not inconsistent_prs else 1
 
 
+def list_referenced_patches(audit: genaudit.Audit, repo: genaudit.GitRepo, args: argparse.Namespace):
+    output = io.StringIO()
+
+    for patch in [patch for topics in audit.topics for patch in topics.patches]:
+        print(patch.render_patch(repo, args.yaml))
+        print()
+
+    return 0
+
+
 def render_audit_report(audit: genaudit.Audit, repo: genaudit.GitRepo, args: argparse.Namespace):
     renderer = genaudit.Renderer(audit, repo)
     if args.out_dir:
@@ -124,6 +134,14 @@ def main():
     merge_commits.add_argument('audit_config_dir',
                                help='the audit directory to be used')
     merge_commits.set_defaults(func=verify_merge_commits)
+
+    list_patches = subparsers.add_parser(
+        'list_patches', help='List all patches that are referenced in the audit document.')
+    list_patches.add_argument('--yaml', action='store_true', default=False,
+                               help='list the patches as YAML document compatible with the topic.yml format')
+    list_patches.add_argument('audit_config_dir',
+                              help='the audit directory to be used')
+    list_patches.set_defaults(func=list_referenced_patches)
 
     renderer = subparsers.add_parser(
         'render', help='Render the audit document.')


### PR DESCRIPTION
This lists all patches referenced in the audit document. A typical use case is to update the news.rst for Botan's release process.

Use like:

```bash
cd docs/audit_report
poetry run python3 -m genaudit.cli -r <path_to_botan_repo_checkout> list_patches changes --yaml
```

Typical output:

```
[...]
# Update BSI TLS Policy to 2023-1  (@securitykernel)
- pr: 3809  # https://github.com/randombit/botan/pull/3809
  merge_commit: dc4ac416125ad294e17cbe925363ec14844341f4
  classification: relevant
  comment: |
    Updates Botan's TLS policy to the latest recommendations of `TR-02102-2 <https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html>`_.
    In particular, enables support for TLS 1.3, adds secp521r1 and increases the required key lengths for RSA and DSA.
    Also sets the minimum key strength to 120 and removes support for FFDHE-2028.
# Add sig algos and key agreements to bench.py  (@securitykernel)
- pr: 3829  # https://github.com/randombit/botan/pull/3829
  merge_commit: 170a7350cebd4fc68ff404a4a85a090107776b74
  classification: out of scope
  auditer: reneme
```