### PR TITLE
Feature: `:srcref:` can deep-link to specific source lines

### DIFF
--- a/docs/cryptodoc/src/05_08_kyber.rst
+++ b/docs/cryptodoc/src/05_08_kyber.rst
@@ -11,7 +11,7 @@ Table :ref:`Supported Kyber parameter sets <pubkey_key_generation/kyber/table_pa
 **Structure**
 
 The IND-CCA2-secure KEM Kyber (Kyber.CCAKEM, Section 1.3, [Kyber-R3]_) is obtained from an IND-CPA-secure public-key encryption scheme (Kyber.CPAPKE, Section 1.2, [Kyber-R3]_) via a modified Fujisaki–Okamoto transform.
-The internal class ``Kyber_KEM_Cryptor`` found in :srcref:`src/lib/pubkey/kyber/kyber_common/kyber.cpp` implements the public-key encryption Kyber.CPAPKE.Enc.
+The internal class ``Kyber_KEM_Cryptor`` found in :srcref:`[src/lib/pubkey/kyber]/kyber_common/kyber.cpp:1042|Kyber_KEM_Cryptor` implements the public-key encryption Kyber.CPAPKE.Enc.
 Its child classes ``Kyber_KEM_Encryptor`` and ``Kyber_KEM_Decryptor`` respectively implement the IND-CCA2-secure KEM Kyber.CCAKEM encapsulation/decapsulation [#kyber_cryptor_class]_.
 
 .. [#kyber_cryptor_class]

--- a/tools/sourceref/sourceref/__init__.py
+++ b/tools/sourceref/sourceref/__init__.py
@@ -5,7 +5,7 @@ from sphinx.application import Sphinx
 import auditinfo
 
 def setup(app: Sphinx):
-    app.add_config_value('src_ref_base_url', f'https://github.com/{auditinfo.botan_github_handle()}/blob', 'html')
+    app.add_config_value('src_ref_base_url', f'https://github.com/{auditinfo.botan_github_handle()}', 'html')
     app.add_config_value('src_ref_reference', auditinfo.botan_git_ref(), 'html')
     app.add_config_value('src_ref_check_url', False, 'env')
 

--- a/tools/sourceref/sourceref/role.py
+++ b/tools/sourceref/sourceref/role.py
@@ -55,7 +55,7 @@ class SourceReferenceRole(ReferenceRole):
             self.text = f".../{match.group(3)}"
 
     def build_uri(self) -> str:
-        return f'{self.env.app.config.src_ref_base_url}/{self.env.app.config.src_ref_reference}/{self.target}'
+        return f'{self.env.app.config.src_ref_base_url}/blob/{self.env.app.config.src_ref_reference}/{self.target}'
 
     def check_url(self, url: str) -> tuple[list[Node], list[system_message]] | None:
         ret = requests.head(url)

--- a/tools/sourceref/sourceref/role.py
+++ b/tools/sourceref/sourceref/role.py
@@ -4,16 +4,89 @@ from docutils import nodes
 from docutils.nodes import Node, system_message
 from sphinx.roles import ReferenceRole
 
+class LinkTarget:
+    extended_target_regex = re.compile(r"^(?:\[(?P<to_be_truncated>[^\]\s:]+)\])?(?P<path>[^\s:]+)(?::(?P<line_number>\d+)\|(?P<validation_search_string>[^\n]*))?$")
+
+    @property
+    def uri(self) -> str:
+        line_extension = f"#L{self.line}" if self.has_line else ''
+        target_url = ''.join([self._truncated, self._path, line_extension])
+        return '/'.join([self._base_url, "blob", self._github_reference, target_url])
+
+    @property
+    def uri_to_raw_file(self) -> str:
+        target_url = ''.join([self._truncated, self._path])
+        return '/'.join([self._base_url, "raw", self._github_reference, target_url])
+
+    @property
+    def text_suggestion(self) -> str:
+        truncation_mark = '...' if self.is_truncated else ''
+        line_extension = f":{self.line}" if self.has_line else ''
+        return f"{truncation_mark}{self._path}{line_extension}"
+
+    @property
+    def has_line(self) -> bool:
+        return self._line != ''
+
+    @property
+    def is_truncated(self) -> bool:
+        return self._truncated != ''
+
+    @property
+    def line(self) -> int:
+        if not self.has_line:
+            raise ValueError("No line number was provided")
+        return int(self._line)
+
+    def check(self) -> str |  None:
+        if self.has_line:
+            ret = requests.get(self.uri_to_raw_file)
+        else:
+            ret = requests.head(self.uri)
+
+        if ret.status_code >= 400:
+            return f"Failed to fetch target URL '{self.uri}' : {ret.status_code} {ret.reason}"
+
+        if self.has_line:
+            lines = ret.text.splitlines()
+            if len(lines) < self.line:
+                return f"Target file '{self.uri}' only has {len(lines)} lines, but line {self.line} was requested."
+            line = lines[self.line - 1]
+            if self.search_string not in line:
+                return f"Target file '{self.uri}' does not contain the expected string '{self.search_string}' in line {self.line}."
+
+        return None
+
+    def __init__(self, target_string: str, base_url: str, reference: str):
+
+        m = self.extended_target_regex.match(target_string)
+        if not m:
+            raise ValueError(f"Invalid target string: {target_string}")
+
+        self._base_url = base_url
+        self._github_reference = reference
+        self._truncated = m['to_be_truncated'] or ''
+        self._path = m['path']
+        self._line = m['line_number'] or ''
+        self.search_string = m['validation_search_string'] or ''
+
+
 class SourceReferenceRole(ReferenceRole):
     """A role to create a reference to a source file.
 
-    The reference will link to ``<src_ref_base_url>/<src_ref_reference>/<target>``.
+    The reference will link to ``<src_ref_base_url>/<src_ref_reference>/<target>[:<line number>|<expected line content>]``.
 
     The text of the role will be the ``<target>``.
     The reference role can also accept ``link title <target>`` style as a text for
     the role.
-    Alternativeley, the target can be displayed truncated. For example:
+    Alternatively, the target can be displayed truncated. For example:
     ``[src/lib/hash]/sha1/sha1.cpp`` is displayed as ``.../sha1/sha1.cpp``.
+
+    The target may optionally include a line number. For instance, to deep-link
+    to a specific function in a source file. Note that the line number MUST be
+    followed by a search string that must match the line's content. That way, CI
+    can verify that the line number still points to the expected content even if
+    the upstream source file changes.
 
     Options:
 
@@ -27,43 +100,23 @@ class SourceReferenceRole(ReferenceRole):
     - ``src/lib/pubkey/xmss/``
     - ``XMSS <src/lib/pubkey/xmss/>``
     - ``[src/lib/hash]/sha1/sha1.cpp``
+    - ``TLS 1.3 key export <src/lib/tls/tls13/tls_cipher_state.cpp:400|CipherState::export_key>``
     """
 
-    truncated_target_re = re.compile(r"\[(.*)(/\]|\]/)(.*)")
-
     def run(self) -> tuple[list[Node], list[system_message]]:
-        self.parse_target()
-        ref_uri = self.build_uri()
+        link_target = LinkTarget(self.target, self.env.app.config.src_ref_base_url, self.env.app.config.src_ref_reference)
 
-        if self.env.app.config.src_ref_check_url:
-            if result := self.check_url(ref_uri):
-                return result
+        # Check that the linked code is reachable and seems up-to-date
+        if self.env.app.config.src_ref_check_url and (errormsg := link_target.check()):
+            msg = self.inliner.reporter.error(errormsg, line=self.lineno)
+            prb = self.inliner.problematic(self.rawtext, self.rawtext, msg)
+            return [prb], [msg]
 
-        ref_node = nodes.reference('', '', internal=False, refuri=ref_uri, **self.options)
+        ref_node = nodes.reference('', '', internal=False, refuri=link_target.uri, **self.options)
         if self.has_explicit_title:
             ref_node += nodes.Text(self.title)
         else:
-            ref_node += nodes.literal(self.text, self.text)
+            text = link_target.text_suggestion
+            ref_node += nodes.literal(text, text)
 
         return [ref_node], []
-
-    def parse_target(self) -> None:
-        """ Check if the target is marked as truncated and adapt the target and text accordingly."""
-        match = self.truncated_target_re.match(self.target)
-        if match:
-            self.target = f"{match.group(1)}/{match.group(3)}"
-            self.text = f".../{match.group(3)}"
-
-    def build_uri(self) -> str:
-        return f'{self.env.app.config.src_ref_base_url}/blob/{self.env.app.config.src_ref_reference}/{self.target}'
-
-    def check_url(self, url: str) -> tuple[list[Node], list[system_message]] | None:
-        ret = requests.head(url)
-        if ret.status_code < 400:
-            return None
-
-        msg = self.inliner.reporter.error(f'invalid source reference to path "{self.target}", GitHub said: {ret.status_code} - {ret.reason} (requested: {url})',
-                                          line=self.lineno)
-        prb = self.inliner.problematic(self.rawtext, self.rawtext, msg)
-        return [prb], [msg]
-


### PR DESCRIPTION
This extends the `:srcref:` rST role with deep-links into specific source lines. This feature was explicitly requested [here](https://github.com/sehlen-bsi/botan-docs/pull/117#discussion_r1487454442). Additionally, I integrated the `:srcref:` extension @FAlbertDev added in #186.

As an example, I deep-linked a source location in the Kyber crypto doc. The result (in HTML output) looks like that:

![image](https://github.com/sehlen-bsi/botan-docs/assets/1562139/e457e5c4-8c5a-4de3-9da4-4cf756177ded)

... and links to: https://github.com/randombit/botan/blob/7f15ce7b39d6bd34dda9af4d2cb08a6e18c64c01/src/lib/pubkey/kyber/kyber_common/kyber.cpp#L1042

### Usage

In reStructuredText the `:srcref:` annotation understands the following:

| Example | Description |
| --- | --- |
| ``:srcref:`src/lib/hash/sha1/sha1.cpp` `` | Simply link to the `sha1.cpp` on GitHub, using the full path as link text, namely "src/lib/hash/sha1/sha1.cpp". |
| ``:srcref:`src/lib/pubkey/xmss/` `` | Simply link to the `xmss` directory on GitHub, using the full path as link text, namely "src/lib/pubkey/xmss". |
| ``:srcref:`XMSS <src/lib/pubkey/xmss/>` `` | Link to the `xmss` directory, using "XMSS" as link text. |
| ``:srcref:`\[src/lib/hash]/sha1/sha1.cpp` `` | Link to the `sha1.cpp`, using an elided path as link text, namely: ".../sha1/sha1.cpp". |
| ``:srcref:`TLS 1.3 key export <src/lib/tls/tls13/tls_cipher_state.cpp:400\|CipherState::export_key>` `` | Deep-link to `tls_cipher_state.cpp` line 400, using "TLS 1.3 key export" as link text. The string `CipherState::export_key` must be found in this line, so that a Continuous Integration job can check that the deep-link didn't get out of sync with the upstream source code. |
| ``:srcref:`\[src/lib/tls/tls13]/tls_cipher_state.cpp:400\|CipherState::export_key>` `` | Deep-link to `tls_cipher_state.cpp` line 400, using an elided path as link text, namely: "...tls_cipher_state.cpp:400". The search string works the same as explained above. |
