### PR TITLE
Chore: Update Things

### DIFF
--- a/.github/actions/setup-build-agent/action.yml
+++ b/.github/actions/setup-build-agent/action.yml
@@ -35,7 +35,7 @@ runs:
       run: print("::warning ::No compiler cache available, build times might suffer")
       shell: python
       if: env.COMPILER_CACHE_LOCATION == '' && inputs.cache-key != ''
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: env.COMPILER_CACHE_LOCATION != '' && inputs.cache-key != ''
       with:
           path: ${{ env.COMPILER_CACHE_LOCATION }}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Fetch Audit Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./source
           fetch-depth: 0
@@ -32,14 +32,14 @@ jobs:
           env_file: ./source/config/botan.env
 
       - name: Fetch Botan Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./botan
           repository: ${{ env.BOTAN_REPO }}
           fetch-depth: 0
 
       - name: Handle the Audit Generator Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./auditupdate_cache
           key: auditupdate_3.1-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: junit
+          name: junit-${{ matrix.platform.host_os }}-${{ matrix.platform.compiler }}-${{ matrix.target }}
           path: junit_reports/*.xml
           if-no-files-found: error
 
@@ -295,7 +295,8 @@ jobs:
       - name: Fetch JUnit Reports
         uses: actions/download-artifact@v4
         with:
-          name: junit
+          pattern: junit-*
+          merge-multiple: true
           path: ${{ github.workspace }}/junit_reports
 
       - name: Install Build Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           path: ./audit_generator_cache
           key: audit_3.1-${{ github.run_id }}
           restore-keys: audit_3.1
+          save-always: true
 
       - name: Verify Patch Coverage
         working-directory: source/docs/audit_report
@@ -151,13 +152,6 @@ jobs:
         if: always()
         env:
           GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Store Audit Generator Cache on Rate Limit Exceeded
-        uses: actions/cache/save@v4
-        if: ${{ failure() && env.API_RATE_LIMIT_EXCEEDED == 'true' }}
-        with:
-          path: ./audit_generator_cache
-          key: audit_3.1-${{ github.run_id }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         working-directory: ${{matrix.element.dir }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Environment Configuration
         uses: ./.github/actions/setup-environment
@@ -47,7 +47,7 @@ jobs:
         run: poetry run make latexpdf
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.element.out_name }}
           path: ${{ matrix.element.dir }}/_build/latex/${{ matrix.element.out_name }}-*.pdf
@@ -67,7 +67,7 @@ jobs:
       run:
         working-directory: ${{matrix.element.dir }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Environment Configuration
         uses: ./.github/actions/setup-environment
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Fetch Audit Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./source
 
@@ -99,7 +99,7 @@ jobs:
           env_file: ./source/config/botan.env
 
       - name: Fetch Botan Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./botan
           repository: ${{ env.BOTAN_REPO }}
@@ -116,7 +116,7 @@ jobs:
         run: gpg --trusted-key 4AEE18F83AFDEB23 --import source/.github/resources/web-flow.gpg
 
       - name: Handle the Audit Generator Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./audit_generator_cache
           key: audit_3.1-${{ github.run_id }}
@@ -153,14 +153,14 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Store Audit Generator Cache on Rate Limit Exceeded
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: ${{ failure() && env.API_RATE_LIMIT_EXCEEDED == 'true' }}
         with:
           path: ./audit_generator_cache
           key: audit_3.1-${{ github.run_id }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: audit_report
           path: source/docs/audit_report/_build/latex/*.pdf
@@ -188,7 +188,7 @@ jobs:
     runs-on: ${{ matrix.host_os }}
     steps:
       - name: Fetch Audit Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./source
 
@@ -198,7 +198,7 @@ jobs:
           env_file: ./source/config/botan.env
 
       - name: Fetch Botan Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./botan
           repository: ${{ env.BOTAN_REPO }}
@@ -218,7 +218,7 @@ jobs:
           ${{ matrix.target }}
 
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifacts }}
@@ -243,7 +243,7 @@ jobs:
 
     steps:
       - name: Fetch Audit Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./source
 
@@ -253,7 +253,7 @@ jobs:
           env_file: ./source/config/botan.env
 
       - name: Fetch Botan Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./botan
           repository: ${{ env.BOTAN_REPO }}
@@ -275,7 +275,7 @@ jobs:
           ${{ matrix.target }}
 
       - name: Store JUnit Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: junit
@@ -291,7 +291,7 @@ jobs:
       run:
         working-directory: docs/testreport
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Environment Configuration
         uses: ./.github/actions/setup-environment
@@ -299,7 +299,7 @@ jobs:
           env_file: ./config/botan.env
 
       - name: Fetch JUnit Reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: junit
           path: ${{ github.workspace }}/junit_reports
@@ -316,7 +316,7 @@ jobs:
           TEST_REPORT_JUNIT_INPUT_DIRECTORY: ${{ github.workspace }}/junit_reports
 
       - name: Store Test Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: testreport
           path: docs/testreport/_build/latex/testreport-*.pdf
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Audit Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./source
 
@@ -337,7 +337,7 @@ jobs:
           env_file: ./source/config/botan.env
 
       - name: Fetch Botan Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./botan
           repository: ${{ env.BOTAN_REPO }}
@@ -348,7 +348,7 @@ jobs:
         run: python3 ${{ github.workspace }}/source/.github/scripts/tarball.py --output-dir build --source-dir botan
 
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: source
           path: build/*.zip
@@ -365,7 +365,7 @@ jobs:
 
     steps:
       - name: Fetch Audit Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./source
 
@@ -375,7 +375,7 @@ jobs:
           env_file: ./source/config/botan.env
 
       - name: Fetch Botan Documentation
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: documentation
           path: staging/botandocs
@@ -388,55 +388,55 @@ jobs:
           cp staging/botandocs/handbook/*.pdf 'final/Handbuch'
 
       - name: Fetch Architecture
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: architecture
           path: final/Architecture
 
       - name: Fetch Audit Method
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: audit_method
           path: final/Audit
 
       - name: Fetch Audit Report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: audit_report
           path: final/Audit
 
       - name: Fetch Coverage Report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
           path: final/Coverage Report
 
       - name: Fetch Cryptographic Documentation
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cryptodoc
           path: final/Kryptodoc
 
       - name: Fetch Source Code
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source
           path: final/Source Code
 
       - name: Fetch Test Report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: testreport
           path: final/Test Report
 
       - name: Fetch Testspezifikation
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: testspec
           path: final/Testspezifikation
 
       - name: Upload Bundled Submission Documents
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Submission Bundle for Botan ${{ env.BOTAN_VERSION }}
           path: final/*

--- a/docs/architecture/poetry.lock
+++ b/docs/architecture/poetry.lock
@@ -407,7 +407,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false

--- a/docs/audit_method/poetry.lock
+++ b/docs/audit_method/poetry.lock
@@ -407,7 +407,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false

--- a/docs/audit_report/poetry.lock
+++ b/docs/audit_report/poetry.lock
@@ -121,7 +121,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "cryptography"
-version = "42.0.3"
+version = "42.0.5"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -540,7 +540,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false

--- a/docs/cryptodoc/poetry.lock
+++ b/docs/cryptodoc/poetry.lock
@@ -407,7 +407,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false

--- a/docs/testreport/poetry.lock
+++ b/docs/testreport/poetry.lock
@@ -121,7 +121,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "cryptography"
-version = "42.0.3"
+version = "42.0.5"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -244,7 +244,7 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "junitparser"
-version = "3.1.1"
+version = "3.1.2"
 description = "Manipulates JUnit/xUnit Result XML files"
 category = "main"
 optional = false
@@ -548,7 +548,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false

--- a/docs/testspec/poetry.lock
+++ b/docs/testspec/poetry.lock
@@ -407,7 +407,7 @@ test = ["pytest"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "dev"
 optional = false

--- a/tools/auditupdate/poetry.lock
+++ b/tools/auditupdate/poetry.lock
@@ -56,7 +56,7 @@ python-versions = ">=3.7.0"
 
 [[package]]
 name = "cryptography"
-version = "42.0.3"
+version = "42.0.5"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false

--- a/tools/genaudit/poetry.lock
+++ b/tools/genaudit/poetry.lock
@@ -56,7 +56,7 @@ python-versions = ">=3.7.0"
 
 [[package]]
 name = "cryptography"
-version = "42.0.3"
+version = "42.0.5"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false


### PR DESCRIPTION
This updates some python dependencies and GitHub Actions.

Note in particular, that `actions/artifacts@v4` enforces immutable artifacts. I.e. we cannot upload to a single `junit` artifact from multiple jobs. Instead, artifacts must be job-unique. Fortunately, `actions/download-artifacts@v4` supports downloading and recombining based on a pattern. See [the official migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact).

Also, `actions/cache@v4` introduces `save-always`, so we can do away with our workaround of saving the API cache on failed jobs.