### PR TITLE
Chore: Use poetry for dependency mgmt only

### DIFF
--- a/docs/architecture/pyproject.toml
+++ b/docs/architecture/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "architecture"
 version = "1.0.0"
+package-mode = false
 description = "Provides a high-level overview of the library and its architecture"
 authors = ["Fabian Albert <fabian.albert@rohde-schwarz.com>","René Fischer <rene.fischer@rohde-schwarz.com>","Philippe Lieser <philippe.lieser@rohde-schwarz.com","René Meusel <rene.meusel@rohde-schwarz.com>","Amos Treiber <amos.treiber@rohde-schwarz.com>"]
 

--- a/docs/audit_method/pyproject.toml
+++ b/docs/audit_method/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "audit_method"
 version = "1.0.0"
+package-mode = false
 description = "Describes the process we use to audit changes in the Botan library"
 authors = ["Fabian Albert <fabian.albert@rohde-schwarz.com>","René Fischer <rene.fischer@rohde-schwarz.com>","Philippe Lieser <philippe.lieser@rohde-schwarz.com","René Meusel <rene.meusel@rohde-schwarz.com>","Amos Treiber <amos.treiber@rohde-schwarz.com>"]
 

--- a/docs/audit_report/pyproject.toml
+++ b/docs/audit_report/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "audit_report"
 version = "1.0.0"
+package-mode = false
 description = "Tracks the auditing results of the latest changes in the Botan library"
 authors = ["Fabian Albert <fabian.albert@rohde-schwarz.com>", "René Meusel <rene.meusel@rohde-schwarz.com>", "Philippe Lieser <philippe.lieser@rohde-schwarz.com"]
 

--- a/docs/cryptodoc/pyproject.toml
+++ b/docs/cryptodoc/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "cryptodoc"
 version = "1.0.0"
+package-mode = false
 description = "Provides details on the implementation of central cryptographic algorithms in Botan"
 authors = ["Fabian Albert <fabian.albert@rohde-schwarz.com>","René Fischer <rene.fischer@rohde-schwarz.com>","Philippe Lieser <philippe.lieser@rohde-schwarz.com","René Meusel <rene.meusel@rohde-schwarz.com>","Amos Treiber <amos.treiber@rohde-schwarz.com>"]
 

--- a/docs/testreport/pyproject.toml
+++ b/docs/testreport/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "test_report"
 version = "1.0.0"
+package-mode = false
 description = "Collects Botan's test outputs and renders them into a document"
 authors = ["Fabian Albert <fabian.albert@rohde-schwarz.com>", "René Meusel <rene.meusel@rohde-schwarz.com>", "Philippe Lieser <philippe.lieser@rohde-schwarz.com"]
 

--- a/docs/testspec/pyproject.toml
+++ b/docs/testspec/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "testspec"
 version = "1.0.0"
+package-mode = false
 description = "Specifies the relevant unit and integration test body of the library"
 authors = ["Fabian Albert <fabian.albert@rohde-schwarz.com>","René Fischer <rene.fischer@rohde-schwarz.com>","Philippe Lieser <philippe.lieser@rohde-schwarz.com","René Meusel <rene.meusel@rohde-schwarz.com>","Amos Treiber <amos.treiber@rohde-schwarz.com>"]
 


### PR DESCRIPTION
I recently switched to Ubuntu 24.04 where poetry starting throwing around warnings about that.
Note that this requires the CI jobs to run on Ubuntu 24.04.