### PR TITLE
FIX: auto-update bot has to run on Ubuntu 24.04

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: write
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     defaults:
       run:


### PR DESCRIPTION
Same poetry argument as #218 