### PR TITLE
Reflect Botan's NIST SP800-56r2 Changes

### DIFF
--- a/docs/cryptodoc/src/00_01_changelog.rst
+++ b/docs/cryptodoc/src/00_01_changelog.rst
@@ -159,4 +159,5 @@ Changelog
    |         |          |                                             |            |
    |         |          | - New PQC algorithms                        |            |
    |         |          |   - HSS/LMS                                 |            |
+   |         |          | - NIST SP800-56Cr2 One-Step KDM with KMAC   |            |
    +---------+----------+---------------------------------------------+------------+

--- a/docs/cryptodoc/src/10_kdf.rst
+++ b/docs/cryptodoc/src/10_kdf.rst
@@ -48,10 +48,18 @@ The implementation of KDF in Double-Pipeline Iteration Mode uses the
 optional counter *i* and fixes the length of :math:`[L]_2` and
 :math:`[i]_2` (the value ``r``) to 32 bits.
 
-NIST SP800-56C
---------------
+NIST SP800-56Cr2 One-Step KDM
+-----------------------------
 
-NIST [SP800-56C]_ defines a key derivation using extraction-then-expansion.
-The implementation can be found in
-:srcref:`src/lib/kdf/sp800_56c/sp800_56c.cpp`. The implementation fixes the
-context value for the expansion step to the empty string.
+NIST [SP800-56Cr2]_ defines a one-step key derivation method based on a hash
+function, HMAC, or KMAC. All three of these options are supported. The
+implementation can be found in
+:srcref:`src/lib/kdf/sp800_56a/sp800_56c_one_step.cpp`.
+
+NIST SP800-56Cr2 Two-Step KDM
+-----------------------------
+
+NIST [SP800-56Cr2]_ defines a two-step key derivation using
+extraction-then-expansion. The implementation can be found in
+:srcref:`src/lib/kdf/sp800_56a/sp800_56c_two_step.cpp`. The implementation
+fixes the context value for the expansion step to the empty string.

--- a/docs/cryptodoc/src/90_bibliographie.rst
+++ b/docs/cryptodoc/src/90_bibliographie.rst
@@ -201,7 +201,7 @@
    https://csrc.nist.gov/publications/detail/sp/800-38e/final,
    January 2010
 
-.. [SP800-56C] NIST Special Publication SP 800-56C Rev. 2:
+.. [SP800-56Cr2] NIST Special Publication SP 800-56C Rev. 2:
    "Recommendation for Key-Derivation Methods in Key-Establishment Schemes",
    https://csrc.nist.gov/publications/detail/sp/800-56c/rev-2/final,
    August 2020

--- a/docs/testspec/src/06_kdf.rst
+++ b/docs/testspec/src/06_kdf.rst
@@ -222,10 +222,10 @@ test vectors are listed in :srcref:`src/tests/data/kdf/sp800_108_pipe.vec`.
    |                        |    result with the expected output value *Out*                          |
    +------------------------+-------------------------------------------------------------------------+
 
-SP 800-56C
-----------
+NIST SP 800-56Cr2 Two-Step KDM
+------------------------------
 
-The NIST SP 800-56C KDF is tested with the following constraints:
+The NIST SP 800-56Cr2 Two-Step KDM is tested with the following constraints:
 
 -  Number of test cases: 40
 -  Source: Generated with PyCryptodome
@@ -245,11 +245,11 @@ test vectors are listed in :srcref:`src/tests/data/kdf/sp800_56c.vec`.
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | KDF-NISTSP800-56C-1                                                     |
+   | **Test Case No.:**     | KDF-NISTSP800-56CR2-Two-Step-1                                          |
    +========================+=========================================================================+
    | **Type:**              | Positive Test                                                           |
    +------------------------+-------------------------------------------------------------------------+
-   | **Description:**       | Derives a key from the NIST SP 800-56C KDF                              |
+   | **Description:**       | Derives a key from the NIST SP 800-56C Two-Step KDM                     |
    +------------------------+-------------------------------------------------------------------------+
    | **Preconditions:**     | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+


### PR DESCRIPTION
As mentioned in #221, I updated the Cryptodoc for the changes in https://github.com/randombit/botan/pull/4121.