### PR TITLE
FIX: audit patch list may be empty

### DIFF
--- a/tools/genaudit/genaudit/topic.py
+++ b/tools/genaudit/genaudit/topic.py
@@ -54,7 +54,7 @@ class Topic:
             else:
                 raise RuntimeError("Patch is neither a Pull Request nor a Commit: %s" % patch)
 
-        if 'patches' not in cfg:
+        if 'patches' not in cfg or cfg['patches'] is None:
             return []
 
         return [load(patch) for patch in cfg['patches']]


### PR DESCRIPTION
This fixes an issue where the audit generator would fail when a topic file contained an empty patch list, as:

```
  title: Example

  description: |
    Irrelevant description...

  patches:
```