### PR TITLE
Render list of Approvers into Patches from Auto-Update 

### DIFF
--- a/tools/auditinfo/auditinfo/auditor.py
+++ b/tools/auditinfo/auditinfo/auditor.py
@@ -7,6 +7,14 @@ class Auditor:
         self.name = name
         self.github_handle = github_handle[1:] if github_handle.startswith('@') else github_handle
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.github_handle == other.github_handle
+
+    def __hash__(self):
+        return self.github_handle.__hash__()
+
 def authorative_auditors() -> list[Auditor]:
     auditors_file = auditors_file_path()
     strm = open(auditors_file, 'r')

--- a/tools/auditupdate/auditupdate/cli.py
+++ b/tools/auditupdate/auditupdate/cli.py
@@ -83,6 +83,9 @@ def main():
     parser.add_argument('-n', '--output-topic-title',
                         help='Title of the topic to append unreferenced patches to',
                         default='Uncategorized Patches')
+    parser.add_argument('-d', '--dry-run',
+                        help='Do not commit or push changes to the repository',
+                        default=False, action='store_true')
     parser.add_argument('audit_config_dir',
                          help='the audit directory to be updated')
 
@@ -129,6 +132,10 @@ def main():
     if not found_patches:
         logging.critical(f"Upstream repo was updated (from {old_target[0:7]} to {new_target[0:7]}) but didn't find new patches. Something is wrong here!")
         return 1
+
+    if args.dry_run:
+        logging.info(f"DRY-RUN: Not committing or pushing changes to the repository.")
+        return 0
 
     # Commit and push the new (uncategorized) patch references.
     run_git(["add", audit.get_topic_file_path(args.output_topic)])

--- a/tools/auditupdate/auditupdate/cli.py
+++ b/tools/auditupdate/auditupdate/cli.py
@@ -48,7 +48,7 @@ def update_uncategorized_patches(audit: genaudit.Audit, repo: genaudit.GitRepo, 
             ]))
 
         # render all found unreferenced patches
-        rendered_unrefed_patches = ''.join([f"\n{patch.render_patch(repo, True)}\n" for patch in unrefed_patches])
+        rendered_unrefed_patches = ''.join([f"\n{patch.render_patch(repo, yaml=True, approvers=True)}\n" for patch in unrefed_patches])
         unrefed_topic.write(rendered_unrefed_patches)
 
     return True


### PR DESCRIPTION
This is how it looks:

```yaml
# Chore: Centralize Strong<> type unwrapping
#   Author:    @reneme
#   Approvals: @FAlbertDev, (@randombit)
- pr: 4170  # https://github.com/randombit/botan/pull/4170
  merge_commit: bb9c069a2688065bf354356190156a34cbce98d2
  classification: unspecified
```

Now we can immediately see that a pull request was approved by some other user prior to merging upstream. Users that are defined as "authorative auditors" in this repository (see `config/auditors.yml`) will be rendered first. All other users will be in parenthesis.

I've been wishing to have this information handy for quite some time while categorizing patches after the auto-update bot had detected them on upstream.