### PR TITLE
Enforce Poetry Version >=1.8.0

### DIFF
--- a/docs/architecture/pyproject.toml
+++ b/docs/architecture/pyproject.toml
@@ -17,5 +17,5 @@ auditinfo = { path = "../../tools/auditinfo", develop = true }
 esbonio = "^0.16.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/docs/audit_method/pyproject.toml
+++ b/docs/audit_method/pyproject.toml
@@ -17,5 +17,5 @@ sourceref = { path = "../../tools/sourceref", develop = true }
 esbonio = "^0.16.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/docs/audit_report/pyproject.toml
+++ b/docs/audit_report/pyproject.toml
@@ -17,5 +17,5 @@ sourceref = { path = "../../tools/sourceref", develop = true }
 esbonio = "^0.16.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/docs/cryptodoc/pyproject.toml
+++ b/docs/cryptodoc/pyproject.toml
@@ -17,5 +17,5 @@ sourceref = { path = "../../tools/sourceref", develop = true }
 esbonio = "^0.16.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/docs/testreport/pyproject.toml
+++ b/docs/testreport/pyproject.toml
@@ -18,5 +18,5 @@ sourceref = { path = "../../tools/sourceref", develop = true }
 esbonio = "^0.16.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/docs/testspec/pyproject.toml
+++ b/docs/testspec/pyproject.toml
@@ -17,5 +17,5 @@ sourceref = { path = "../../tools/sourceref", develop = true }
 esbonio = "^0.16.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tools/auditinfo/pyproject.toml
+++ b/tools/auditinfo/pyproject.toml
@@ -11,5 +11,5 @@ pyyaml = "^6.0"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tools/auditupdate/pyproject.toml
+++ b/tools/auditupdate/pyproject.toml
@@ -17,5 +17,5 @@ genaudit = { path = "../genaudit", develop = true }
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tools/auditutils/pyproject.toml
+++ b/tools/auditutils/pyproject.toml
@@ -10,5 +10,5 @@ python = "^3.10"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tools/genaudit/pyproject.toml
+++ b/tools/genaudit/pyproject.toml
@@ -16,5 +16,5 @@ auditinfo = { path = "../auditinfo", develop = true }
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tools/sourceref/pyproject.toml
+++ b/tools/sourceref/pyproject.toml
@@ -14,5 +14,5 @@ auditinfo = { path = "../auditinfo", develop = true }
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tools/tarball_checker/pyproject.toml
+++ b/tools/tarball_checker/pyproject.toml
@@ -12,5 +12,5 @@ auditinfo = { path = "../auditinfo", develop = true }
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
When running poetry install with my default apt install poetry version on my Ubuntu 22.04 I get the (somehow cryptic) error:
```
The Poetry configuration is invalid:
  - Additional properties are not allowed ('package-mode' was unexpected)
```
This is due to the small poetry version. Hopefully, this PR improves this error message for others.