### PR TITLE
Testspec Update: ML-KEM, ML-DSA and SLH-DSA

### DIFF
--- a/docs/testspec/src/12_pubkey_kem.rst
+++ b/docs/testspec/src/12_pubkey_kem.rst
@@ -109,53 +109,59 @@ tests are in *src/tests/data/pubkey/frodokem_kat.vec*.
    |                        |    with the original private key. Expect a decryption failure.          |
    +------------------------+-------------------------------------------------------------------------+
 
-Kyber
-~~~~~
+ML-KEM
+~~~~~~
 
-The implementation is tested for correctness using the Known Answer Test vectors
-demanded by the NIST submission and provided by the reference implementation.
+The implementation is tested for correctness using Known Answer Test vectors
+generated using an implementation associated with the ACVP project.
 
 Additionally, Botan has implementation-specific test cases. Those ensure the
 interoperability of the algorithm when using Botan's generic API for public key
 algorithms. These test cases are equal for all public key schemes and are
 therefore not discussed in detail in this chapter.
 
-All kyber-specific test code can be found in :srcref:`src/tests/test_kyber.cpp`.
-Relevant test data vectors for the KAT tests are in
-*src/tests/data/pubkey/kyber\_\*.vec* where *\** is a placeholder for the
-algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
-*1024_90s*.
+All ML-KEM-specific test code can be found in
+:srcref:`src/tests/test_kyber.cpp`.
+Relevant test data vectors for the ML-KEM KAT tests are in
+:srcref:`[src/tests/data/pubkey]/kyber_encodings.vec`,
+:srcref:`[src/tests/data/pubkey]/ml_kem.vec`,
+:srcref:`[src/tests/data/pubkey]/ml_kem_acvp_keygen.vec`, and
+:srcref:`[src/tests/data/pubkey]/ml_kem_acvp_encap.vec`. Additionally, the
+vectors for testing the still supported Kyber (NIST Round 3 submission)
+instances are in :srcref:`[src/tests/data/pubkey]/kyber_kat.vec`.
 
 .. table::
    :class: longtable
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKENC-KYBER-1                                                           |
+   | **Test Case No.:**     | PKENC-ML-KEM-1                                                          |
    +========================+=========================================================================+
    | **Type:**              | Known Answer Tests                                                      |
    +------------------------+-------------------------------------------------------------------------+
-   | **Description:**       | Uses the KAT vectors of Kyber's reference implementation as specified   |
-   |                        | in the NIST submission                                                  |
+   | **Description:**       | Uses the KAT vectors for ML-KEM.                                        |
    +------------------------+-------------------------------------------------------------------------+
    | **Preconditions:**     | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+
    | **Input Values:**      | Test Vectors with RNG seed inputs in:                                   |
    |                        |                                                                         |
+   |                        | * :srcref:`src/tests/data/pubkey/ml_kem.vec`                            |
    |                        | * :srcref:`src/tests/data/pubkey/kyber_kat.vec`                         |
    +------------------------+-------------------------------------------------------------------------+
    | **Expected Output:**   | Above described test vector files contain expected values for:          |
    |                        |                                                                         |
-   |                        | * Kyber Public Key                                                      |
-   |                        | * Kyber Private Key                                                     |
+   |                        | * ML-KEM Public Key                                                     |
+   |                        | * ML-KEM Private Key                                                    |
    |                        | * Ciphertext                                                            |
    |                        | * Shared Secret                                                         |
+   |                        | * Invalid Ciphertext                                                    |
+   |                        | * Shared Secret for Invalid Ciphertext                                  |
    +------------------------+-------------------------------------------------------------------------+
    | **Steps:**             | For each KAT vector:                                                    |
    |                        |                                                                         |
    |                        | #. Seed a AES-256-CTR-DRBG with the specified RNG seed                  |
    |                        |                                                                         |
-   |                        | #. Use the seeded RNG to generate a Kyber key pair and compare it to    |
+   |                        | #. Use the seeded RNG to generate a ML-KEM key pair and compare it to   |
    |                        |    the expected public and private key in the test vector. This uses    |
    |                        |    the key encoding as implemented in the reference implementation.     |
    |                        |                                                                         |
@@ -173,6 +179,10 @@ algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
    |                        | #. Decapsulate the just-calculated ciphertext with the private key from |
    |                        |    the test vector and ensure that the resulting shared secret is equal |
    |                        |    to the expected value from the test vector                           |
+   |                        |                                                                         |
+   |                        | #. Decapsulate the invalid ciphertext with the private key from the     |
+   |                        |    test vector and ensure that the resulting shared secret is equal to  |
+   |                        |    the expected value from the test vector.                             |
    +------------------------+-------------------------------------------------------------------------+
 
 .. table::
@@ -180,7 +190,7 @@ algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKENC-KYBER-2                                                           |
+   | **Test Case No.:**     | PKENC-ML-KEM-2                                                          |
    +========================+=========================================================================+
    | **Type:**              | Positive Test                                                           |
    +------------------------+-------------------------------------------------------------------------+
@@ -193,8 +203,7 @@ algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
    +------------------------+-------------------------------------------------------------------------+
    | **Expected Output:**   | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+
-   | **Steps:**             | #. Generate a kyber key pair (one for each algorithm parameter          |
-   |                        |    combination: [512, 768, 1024] and [90s, modern]).                    |
+   | **Steps:**             | #. Generate an ML-KEM key pair (one for each ML-KEM or Kyber instance). |
    |                        |                                                                         |
    |                        | #. Encode both the public and private key using the default encoding.   |
    |                        |                                                                         |
@@ -203,7 +212,7 @@ algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
    |                        | #. Decode the private key and decapsulate the above-generated           |
    |                        |    ciphertext.                                                          |
    |                        |                                                                         |
-   |                        | #. Check that both resulting shared secrets are equal                   |
+   |                        | #. Check that both resulting shared secrets are equal.                  |
    +------------------------+-------------------------------------------------------------------------+
 
 .. table::
@@ -211,7 +220,7 @@ algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKENC-KYBER-3                                                           |
+   | **Test Case No.:**     | PKENC-ML-KEM-3                                                          |
    +========================+=========================================================================+
    | **Type:**              | Negative Test                                                           |
    +------------------------+-------------------------------------------------------------------------+
@@ -225,8 +234,7 @@ algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
    +------------------------+-------------------------------------------------------------------------+
    | **Expected Output:**   | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+
-   | **Steps:**             | #. Generate a kyber key pair (one for each algorithm parameter          |
-   |                        |    combination: [512, 768, 1024] and [90s, modern]).                    |
+   | **Steps:**             | #. Generate a kyber key pair (one for each ML-KEM or Kyber instance).   |
    |                        |                                                                         |
    |                        | #. Encode both the public and private key using the default encoding.   |
    |                        |                                                                         |
@@ -248,7 +256,7 @@ algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKENC-KYBER-4                                                           |
+   | **Test Case No.:**     | PKENC-ML-KEM-4                                                          |
    +========================+=========================================================================+
    | **Type:**              | Encoding Tests                                                          |
    +------------------------+-------------------------------------------------------------------------+
@@ -269,6 +277,70 @@ algorithm parameters, namely *512*, *512_90s*, *768*, *768_90s*, *1024* and
    |                        | #. Otherwise re-encode the public and private keys and validate that    |
    |                        |    the result is byte-compatible with the input values.                 |
    +------------------------+-------------------------------------------------------------------------+
+
+
+.. table::
+   :class: longtable
+   :widths: 20 80
+
+   +------------------------+-------------------------------------------------------------------------+
+   | **Test Case No.:**     | PKENC-ML-KEM-5                                                          |
+   +========================+=========================================================================+
+   | **Type:**              | Known Answer Tests                                                      |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Description:**       | ACVP Encapsulation Test                                                 |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Preconditions:**     | None                                                                    |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Input Values:**      | File :srcref:`[src/tests/data/pubkey]/ml_kem_acvp_encap.vec`            |
+   |                        | with values:                                                            |
+   |                        |                                                                         |
+   |                        | * ML-KEM Public Key                                                     |
+   |                        | * Encapsulation Message                                                 |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Expected Output:**   | The above described test vector file contains expected values for:      |
+   |                        |                                                                         |
+   |                        | * Ciphertext                                                            |
+   |                        | * Shared Secret                                                         |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Steps:**             | #. Insert the encapsulation message into a test RNG so that             |
+   |                        |    the RNG selects it when selecting a random message                   |
+   |                        |                                                                         |
+   |                        | #. Perform an encapsulation and compare the results with the KAT values |
+   +------------------------+-------------------------------------------------------------------------+
+
+
+.. table::
+   :class: longtable
+   :widths: 20 80
+
+   +------------------------+-------------------------------------------------------------------------+
+   | **Test Case No.:**     | PKENC-ML-KEM-6                                                          |
+   +========================+=========================================================================+
+   | **Type:**              | Known Answer Tests                                                      |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Description:**       | ACVP Key Generation Test                                                |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Preconditions:**     | None                                                                    |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Input Values:**      | File :srcref:`[src/tests/data/pubkey]/ml_kem_acvp_keygen.vec`           |
+   |                        | with values:                                                            |
+   |                        |                                                                         |
+   |                        | * Key Generation Seed ``d``                                             |
+   |                        | * Implicit Rejection Seed ``z``                                         |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Expected Output:**   | The above described test vector file contains expected values for:      |
+   |                        |                                                                         |
+   |                        | * Public Key                                                            |
+   |                        | * Private Key                                                           |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Steps:**             | #. Insert ``d`` and ``z`` into a test RNG so that                       |
+   |                        |    the RNG selects it when selecting the seeds for key generation       |
+   |                        |                                                                         |
+   |                        | #. Perform a key generation and compare the result with the KAT values. |
+   |                        |    Also check generic algorithm properties of the resulting keys        |
+   +------------------------+-------------------------------------------------------------------------+
+
 
 RSA-KEM
 ~~~~~~~

--- a/docs/testspec/src/12_pubkey_kem.rst
+++ b/docs/testspec/src/12_pubkey_kem.rst
@@ -113,7 +113,7 @@ ML-KEM
 ~~~~~~
 
 The implementation is tested for correctness using Known Answer Test vectors
-generated using an implementation associated with the ACVP project.
+of the ACVP project and of `Kris Kwiatkowski <https://github.com/post-quantum-cryptography/KAT>`_.
 
 Additionally, Botan has implementation-specific test cases. Those ensure the
 interoperability of the algorithm when using Botan's generic API for public key
@@ -139,7 +139,7 @@ instances are in :srcref:`[src/tests/data/pubkey]/kyber_kat.vec`.
    +========================+=========================================================================+
    | **Type:**              | Known Answer Tests                                                      |
    +------------------------+-------------------------------------------------------------------------+
-   | **Description:**       | Uses the KAT vectors for ML-KEM.                                        |
+   | **Description:**       | Uses the KAT vectors for ML-KEM/Kyber.                                  |
    +------------------------+-------------------------------------------------------------------------+
    | **Preconditions:**     | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+

--- a/docs/testspec/src/14_pubkey_sig.rst
+++ b/docs/testspec/src/14_pubkey_sig.rst
@@ -395,59 +395,59 @@ described here in the following.
    |                        | #. Check that the key is valid (see PKSIG-KEY-1)                        |
    +------------------------+-------------------------------------------------------------------------+
 
-Dilithium
----------
+ML-DSA
+------
 
-The implementation is tested for correctness using the Known Answer Test vectors
-demanded by the NIST submission and provided by the reference implementation.
+The implementation is tested for correctness using Known Answer Test vectors
+generated using an implementation associated with the ACVP project.
 
 Additionally, Botan has implementation-specific test cases. Those ensure the
 interoperability of the algorithm when using Botan's generic API for public key
 algorithms. These test cases are equal for all public key schemes and are
 therefore not discussed in detail in this chapter.
 
-All Dilithium-specific test code can be found in
+All ML-DSA-specific test code can be found in
 :srcref:`src/tests/test_dilithium.cpp`. Relevant test data vectors for the KAT tests
-are in *src/tests/data/pubkey/dilithium\_\*.vec* where *\** is a placeholder for
-the algorithm parameters, namely *4x4\_Deterministic*, *6x5\_Deterministic*,
-*8x7\_Deterministic*, *4x4\_Randomized*, *6x5\_Randomized*, *8x7\_Randomized*,
-*4x4\_AES\_Deterministic*, *6x5\_AES\_Deterministic*, *8x7\_AES\_Deterministic*,
-*4x4\_AES\_Randomized*, *6x5\_AES\_Randomized* and *8x7\_AES\_Randomized*.
+are in
+:srcref:`[src/tests/data/pubkey]/ml-dsa-4x4_Deterministic.vec`,
+:srcref:`[src/tests/data/pubkey]/ml-dsa-4x4_Randomized.vec`,
+:srcref:`[src/tests/data/pubkey]/ml-dsa-6x5_Deterministic.vec`,
+:srcref:`[src/tests/data/pubkey]/ml-dsa-6x5_Randomized.vec`,
+:srcref:`[src/tests/data/pubkey]/ml-dsa-8x7_Deterministic.vec`, and
+:srcref:`[src/tests/data/pubkey]/ml-dsa-8x7_Randomized.vec`.
+Additionally, the vectors for testing the still supported Dilithium
+(NIST Round 3 submission) instances are in :srcref:`src/tests/data/pubkey/`
+with prefix ``dilithium`` and the same naming scheme.
+
 
 .. table::
    :class: longtable
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKSIG-DILITHIUM-1                                                       |
+   | **Test Case No.:**     | PKSIG-ML-DSA-1                                                          |
    +========================+=========================================================================+
    | **Type:**              | Known Answer Tests                                                      |
    +------------------------+-------------------------------------------------------------------------+
-   | **Description:**       | Uses the KAT vectors of Dilithium's reference implementation as         |
-   |                        | specified in the NIST submission. Also implements a negative test by    |
+   | **Description:**       | Uses KAT vectors for ML-DSA. Also implements a negative test by         |
    |                        | randomly pertubing the generated signatures before validation.          |
    +------------------------+-------------------------------------------------------------------------+
    | **Preconditions:**     | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+
    | **Input Values:**      | Test Vectors with RNG seed and test messages inputs in:                 |
    |                        |                                                                         |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_4x4_Deterministic.vec`       |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_6x5_Deterministic.vec`       |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_8x7_Deterministic.vec`       |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_4x4_Randomized.vec`          |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_6x5_Randomized.vec`          |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_8x7_Randomized.vec`          |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_4x4_AES_Deterministic.vec`   |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_6x5_AES_Deterministic.vec`   |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_8x7_AES_Deterministic.vec`   |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_4x4_AES_Randomized.vec`      |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_6x5_AES_Randomized.vec`      |
-   |                        | * :srcref:`src/tests/data/pubkey/dilithium_8x7_AES_Randomized.vec`      |
+   |                        | * :srcref:`[src/tests/data/pubkey]/ml-dsa-4x4_Deterministic.vec`        |
+   |                        | * :srcref:`[src/tests/data/pubkey]/ml-dsa-6x5_Deterministic.vec`        |
+   |                        | * :srcref:`[src/tests/data/pubkey]/ml-dsa-8x7_Deterministic.vec`        |
+   |                        | * :srcref:`[src/tests/data/pubkey]/ml-dsa-4x4_Randomized.vec`           |
+   |                        | * :srcref:`[src/tests/data/pubkey]/ml-dsa-6x5_Randomized.vec`           |
+   |                        | * :srcref:`[src/tests/data/pubkey]/ml-dsa-8x7_Randomized.vec`           |
+   |                        | * Dilithium test vectors in :srcref:`src/tests/data/pubkey/`            |
    +------------------------+-------------------------------------------------------------------------+
    | **Expected Output:**   | Above described test vector files contain expected values for:          |
    |                        |                                                                         |
-   |                        | * Dilithium Public Key                                                  |
-   |                        | * Dilithium Private Key                                                 |
+   |                        | * ML-DSA Public Key                                                     |
+   |                        | * ML-DSA Private Key                                                    |
    |                        | * Signature                                                             |
    |                        |                                                                         |
    |                        | to save disk space, these are stored as their SHA-3 digests only.       |
@@ -456,7 +456,7 @@ the algorithm parameters, namely *4x4\_Deterministic*, *6x5\_Deterministic*,
    |                        |                                                                         |
    |                        | #. Seed a AES-256-CTR-DRBG with the specified RNG seed                  |
    |                        |                                                                         |
-   |                        | #. Use the seeded RNG to generate a Dilithium key pair and compare it   |
+   |                        | #. Use the seeded RNG to generate a ML-DSA key pair and compare it      |
    |                        |    to the expected public and private key in the test vector. This uses |
    |                        |    the key encoding as implemented in the reference implementation and  |
    |                        |    first hashes the keys with SHA-3 to save space in the test data.     |
@@ -480,7 +480,7 @@ the algorithm parameters, namely *4x4\_Deterministic*, *6x5\_Deterministic*,
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKSIG-DILITHIUM-2                                                       |
+   | **Test Case No.:**     | PKSIG-ML-DSA-2                                                          |
    +========================+=========================================================================+
    | **Type:**              | Positive and Negative Tests                                             |
    +------------------------+-------------------------------------------------------------------------+
@@ -493,8 +493,7 @@ the algorithm parameters, namely *4x4\_Deterministic*, *6x5\_Deterministic*,
    +------------------------+-------------------------------------------------------------------------+
    | **Expected Output:**   | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+
-   | **Steps:**             | For each combination of the algorithm parameters [4x4, 6x5, 8x7],       |
-   |                        | [Randomized, Determinstic] and [AES, modern]:                           |
+   | **Steps:**             | For each ML-DSA (and Dilithium) algorithm instance:                     |
    |                        |                                                                         |
    |                        | #. Generate a random key pair                                           |
    |                        |                                                                         |
@@ -518,6 +517,37 @@ the algorithm parameters, namely *4x4\_Deterministic*, *6x5\_Deterministic*,
    |                        | #. Decode the keypair again (via Botan's generic interface)             |
    |                        |                                                                         |
    |                        | #. Ensure that these decoded keys work for signing and verifying.       |
+   +------------------------+-------------------------------------------------------------------------+
+
+.. table::
+   :class: longtable
+   :widths: 20 80
+
+   +------------------------+-------------------------------------------------------------------------+
+   | **Test Case No.:**     | PKENC-ML-DSA-2                                                          |
+   +========================+=========================================================================+
+   | **Type:**              | Positive Test                                                           |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Description:**       | Generate random key pairs, serialize and deserialize them, use the      |
+   |                        | deserialized keys to encapsulate and decapsulate secrets.               |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Preconditions:**     | None                                                                    |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Input Values:**      | None                                                                    |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Expected Output:**   | None                                                                    |
+   +------------------------+-------------------------------------------------------------------------+
+   | **Steps:**             | #. Generate an ML-DSA key pair                                          |
+   |                        |    (one for each ML-DSA or Dilithium instance).                         |
+   |                        |                                                                         |
+   |                        | #. Encode both the public and private key using the default encoding.   |
+   |                        |                                                                         |
+   |                        | #. Decode the public key and encapsulate a secret with the decoded key. |
+   |                        |                                                                         |
+   |                        | #. Decode the private key and decapsulate the above-generated           |
+   |                        |    ciphertext.                                                          |
+   |                        |                                                                         |
+   |                        | #. Check that both resulting shared secrets are equal.                  |
    +------------------------+-------------------------------------------------------------------------+
 
 DSA

--- a/docs/testspec/src/14_pubkey_sig.rst
+++ b/docs/testspec/src/14_pubkey_sig.rst
@@ -399,7 +399,8 @@ ML-DSA
 ------
 
 The implementation is tested for correctness using Known Answer Test vectors
-generated using an implementation associated with the ACVP project.
+generated using an ACVP tested
+`python implementation <https://github.com/mjosaarinen/py-acvp-pqc/tree/e37f6ffcd5a6a3f5ac718e853daf3aaeeb07995d>`_.
 
 Additionally, Botan has implementation-specific test cases. Those ensure the
 interoperability of the algorithm when using Botan's generic API for public key
@@ -524,12 +525,12 @@ with prefix ``dilithium`` and the same naming scheme.
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKENC-ML-DSA-2                                                          |
+   | **Test Case No.:**     | PKSIG-ML-DSA-3                                                          |
    +========================+=========================================================================+
    | **Type:**              | Positive Test                                                           |
    +------------------------+-------------------------------------------------------------------------+
    | **Description:**       | Generate random key pairs, serialize and deserialize them, use the      |
-   |                        | deserialized keys to encapsulate and decapsulate secrets.               |
+   |                        | deserialized keys to sign messages and verify signatures.               |
    +------------------------+-------------------------------------------------------------------------+
    | **Preconditions:**     | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+
@@ -542,12 +543,10 @@ with prefix ``dilithium`` and the same naming scheme.
    |                        |                                                                         |
    |                        | #. Encode both the public and private key using the default encoding.   |
    |                        |                                                                         |
-   |                        | #. Decode the public key and encapsulate a secret with the decoded key. |
+   |                        | #. Decode the private key and sign a message with the decoded key.      |
    |                        |                                                                         |
-   |                        | #. Decode the private key and decapsulate the above-generated           |
-   |                        |    ciphertext.                                                          |
-   |                        |                                                                         |
-   |                        | #. Check that both resulting shared secrets are equal.                  |
+   |                        | #. Decode the public key and verify the above-generated                 |
+   |                        |    signature.                                                           |
    +------------------------+-------------------------------------------------------------------------+
 
 DSA
@@ -1557,7 +1556,8 @@ SLH-DSA
 -------
 
 The implementation is tested for correctness using Known Answer Test vectors
-generated using an implementation associated with the ACVP project.
+generated using an ACVP tested
+`python implementation <https://github.com/mjosaarinen/py-acvp-pqc/tree/e37f6ffcd5a6a3f5ac718e853daf3aaeeb07995d>`_.
 Given SLH-DSA's performance characteristics, each supported algorithm
 parameterization gets just a single KAT test.
 

--- a/docs/testspec/src/14_pubkey_sig.rst
+++ b/docs/testspec/src/14_pubkey_sig.rst
@@ -1553,17 +1553,17 @@ constraints for this test case are:
    |                        |    #. E >= 2                                                            |
    +------------------------+-------------------------------------------------------------------------+
 
-SPHINCS+
---------
+SLH-DSA
+-------
 
-The implementation is tested for correctness using the Known Answer Test vectors
-demanded by the NIST submission and provided by the reference implementation.
-Given SPHINCS+' performance characteristics, each supported algorithm
+The implementation is tested for correctness using Known Answer Test vectors
+generated using an implementation associated with the ACVP project.
+Given SLH-DSA's performance characteristics, each supported algorithm
 parameterization gets just a single KAT test.
 
 Along with those integration tests Botan comes with a number of unit tests whose
 vectors were also extracted from intermediate results of the reference
-implementation. Particularly, the SPHINCS+-specific implementation of WOTS+ and
+implementation. Particularly, the SLH-DSA-specific implementation of WOTS+ and
 FORS is covered by those unit tests.
 
 Additionally, Botan has implementation-specific test cases. Those ensure the
@@ -1576,35 +1576,35 @@ therefore not discussed in detail in this chapter.
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKSIG-SPHINCS+-1                                                        |
+   | **Test Case No.:**     | PKSIG-SLH-DSA-1                                                         |
    +========================+=========================================================================+
    | **Type:**              | Known Answer Tests                                                      |
    +------------------------+-------------------------------------------------------------------------+
-   | **Description:**       | Uses the KAT vectors as specified in the API specification of the NIST  |
-   |                        | competition [#NISTAPI]_  and generated using the reference              |
-   |                        | implementation revision 06f42f47 [#SPXrefimpl]_                         |
+   | **Description:**       | Uses the KAT vectors for SLH-DSA                                        |
    +------------------------+-------------------------------------------------------------------------+
    | **Preconditions:**     | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+
    | **Input Values:**      | Test Vectors with RNG seed and test messages inputs in:                 |
    |                        |                                                                         |
+   |                        | * :srcref:`src/tests/data/pubkey/slh_dsa.vec`                           |
    |                        | * :srcref:`src/tests/data/pubkey/sphincsplus.vec`                       |
    +------------------------+-------------------------------------------------------------------------+
    | **Expected Output:**   | Above described test vector files contain expected values for:          |
    |                        |                                                                         |
-   |                        | * SPHINCS+ Public Key                                                   |
-   |                        | * SPHINCS+ Private Key                                                  |
+   |                        | * SLH-DSA Public Key                                                    |
+   |                        | * SLH-DSA Private Key                                                   |
+   |                        | * Signature (Deterministic)                                             |
    |                        | * Signature                                                             |
    |                        |                                                                         |
    |                        | to save disk space, the expected signature is stored as a digest only.  |
-   |                        | We use the same hash function of the respective SPHINCS+ instantiation. |
+   |                        | We use the same hash function of the respective SLH-DSA instantiation.  |
    +------------------------+-------------------------------------------------------------------------+
    | **Steps:**             | For each KAT vector:                                                    |
    |                        |                                                                         |
    |                        | #. Seed a AES-256-CTR-DRBG with the specified RNG seed and pull the     |
-   |                        |    entropy bits needed for generating a SPHINCS+ keypair from it.       |
+   |                        |    entropy bits needed for generating a SLH-DSA keypair from it.        |
    |                        |                                                                         |
-   |                        | #. Generate a SPHINCS+ key pair and validate that it corresponds to the |
+   |                        | #. Generate a SLH-DSA key pair and validate that it corresponds to the  |
    |                        |    expected key pair in the test vector.                                |
    |                        |                                                                         |
    |                        | #. Sign the message provided in the test vector with the just-generated |
@@ -1625,28 +1625,16 @@ therefore not discussed in detail in this chapter.
    |                        |    signature.                                                           |
    +------------------------+-------------------------------------------------------------------------+
 
-.. [#NISTAPI]
-
-   API description for NIST submissions. See section "Additional functions" for
-   a description how Known Answer Tests are to be structured
-   https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/example-files/api-notes.pdf
-
-.. [#SPXrefimpl]
-
-   Revision of the SPHINCS+ reference implementation used as the basis for the
-   implementation in Botan
-   https://github.com/sphincs/sphincsplus/commit/06f42f47491085ac879a72b486ca8edb10891963
-
 .. table::
    :class: longtable
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKSIG-SPHINCS+-2                                                        |
+   | **Test Case No.:**     | PKSIG-SLH-DSA-2                                                         |
    +========================+=========================================================================+
    | **Type:**              | Known Answer Test                                                       |
    +------------------------+-------------------------------------------------------------------------+
-   | **Description:**       | Ensures that the WOTS+ sub-component of SPHINCS+ works as expected.     |
+   | **Description:**       | Ensures that the WOTS+ sub-component of SLH-DSA works as expected.      |
    +------------------------+-------------------------------------------------------------------------+
    | **Preconditions:**     | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+
@@ -1677,11 +1665,11 @@ therefore not discussed in detail in this chapter.
    :widths: 20 80
 
    +------------------------+-------------------------------------------------------------------------+
-   | **Test Case No.:**     | PKSIG-SPHINCS+-3                                                        |
+   | **Test Case No.:**     | PKSIG-SLH-DSA-3                                                         |
    +========================+=========================================================================+
    | **Type:**              | Known Answer Test                                                       |
    +------------------------+-------------------------------------------------------------------------+
-   | **Description:**       | Ensures that the FORS sub-component of SPHINCS+ works as expected.      |
+   | **Description:**       | Ensures that the FORS sub-component of SLH-DSA works as expected.       |
    +------------------------+-------------------------------------------------------------------------+
    | **Preconditions:**     | None                                                                    |
    +------------------------+-------------------------------------------------------------------------+


### PR DESCRIPTION
This PR contains the testspec adaptions for the three new FIPS 20X algorithms. I kept the level of detail roughly the same.