### PR TITLE
3.6.0 Audit: Crystals, CT Helpers, Encoding, Fixes

### DIFF
--- a/docs/audit_report/changes/topics/crystals.yml
+++ b/docs/audit_report/changes/topics/crystals.yml
@@ -1,27 +1,40 @@
 title: Kyber/Dilithium Overhaul
 
+description: |
+  The changes of this section are related to the refactoring of Kyber and Dilithium
+  prior to the ML-KEM and ML-DSA integration.
 patches:
 # Refactor: Have a common base for Kyber/Dilithium structures  (@reneme)
 - pr: 4024  # https://github.com/randombit/botan/pull/4024
   merge_commit: 2fe687bf60b8eda1048cfe92f73ba2568cf53172
-  classification: unspecified
+  classification: critical
+  comment: |
+    This PR refactors the Kyber and Dilithium implementation to have a common base.
+    Especially regarding polynomials, both schemes share common structures that
+    are unified with this PR.
 
 # Fix: Kyber MSVC Warnings
 #   Author:    @FAlbertDev
 #   Approvals: @reneme
 - pr: 4294  # https://github.com/randombit/botan/pull/4294
   merge_commit: b227a5db61faa5b4fec6bc58f7c412f7497e0b94
-  classification: unspecified
+  classification: info
 
 # Fix GCC warning
 #   Author:    @randombit
 - pr: 4301  # https://github.com/randombit/botan/pull/4301
   merge_commit: b4681247060096f08cb62fb966c51d259526474f
-  classification: unspecified
+  classification: info
+  auditer: FAlbertDev
 
 # FIX: Assertion may be false for untrusted data
 #   Author:    @reneme
 #   Approvals: (@randombit)
 - pr: 4391  # https://github.com/randombit/botan/pull/4391
   merge_commit: 3a62c9ab5fc082578a9a1483b15ff7a3d0a4474b
-  classification: unspecified
+  classification: relevant
+  comment: |
+    Prevents that an unintended debug assertion exception is thrown
+    when a decoding exception is expected. Only relevant for
+    builds with enabled debug assertions.
+

--- a/docs/audit_report/changes/topics/ct_helpers.yml
+++ b/docs/audit_report/changes/topics/ct_helpers.yml
@@ -1,58 +1,83 @@
 title: Constant Time Validation Helpers
 
+description: |
+  This topic covers changes related to Botan's constant time helpers.
+  Most notably, the infrastructure for Valgrind checks has been
+  improved. The latest implementations have been updated to incorporate
+  Valgrind's constant-time checks.
+
 patches:
 # Add CT::Option  (@randombit)
 - pr: 4175  # https://github.com/randombit/botan/pull/4175
   merge_commit: e280c77f7aaa0f363460464fcee194a99daa3f7c
-  classification: unspecified
+  classification: critical
+  comment: |
+    Add CT::Option, a helper class similar to std::optional
+    that can contain a value or none. In contrast to std::optional,
+    CT::Option is designed to be used in constant time contexts.
 
 # CT::poison() for Curve448  (@reneme)
 - pr: 4204  # https://github.com/randombit/botan/pull/4204
   merge_commit: 6945e9042c110fb875a0cee558224b5ba7056181
-  classification: unspecified
+  classification: relevant
+  comment: |
+    Add Valgrind constant time checks to the Curve448 implementation.
 
 # CT::poison() for FrodoKEM  (@reneme)
 - pr: 4198  # https://github.com/randombit/botan/pull/4198
   merge_commit: 2bc1985a20d69b9ba389704bfedf01a14af3a876
-  classification: unspecified
+  classification: relevant
+  comment: |
+    Add Valgrind constant time checks to the FrodoKEM implementation.
 
 # Convenience overloads for CT::poison()  (@reneme)
 - pr: 4197  # https://github.com/randombit/botan/pull/4197
   merge_commit: 6c92e4b9a3f8e2ddc802f117eb81984ba2e89987
-  classification: unspecified
+  classification: relevant
 
 # Adopt new convention for CT poisoning in pcurves  (@randombit)
 - pr: 4207  # https://github.com/randombit/botan/pull/4207
   merge_commit: 041ff245011287fb30597ba86f64020a3df61110
-  classification: unspecified
+  classification: info
+  comment: |
+    Update the pcurve implementations to use the new convenience
+    Valgrind methods.
 
 # Test: Run a self-test for our valgrind setup  (@reneme)
 - pr: 4182  # https://github.com/randombit/botan/pull/4182
   merge_commit: 25541afe95b8154d2c96df7f15d46e656b217340
-  classification: unspecified
+  classification: info
 
 # CT::poison for CRYSTALS Kyber and Dilithium  (@reneme)
 - pr: 4223  # https://github.com/randombit/botan/pull/4223
   merge_commit: 3fa77189c7cb1a1922c5c0ed73dd663fe6e8fbaf
-  classification: unspecified
+  classification: relevant
+  comment: |
+    Add Valgrind constant time checks to the Kyber
+    and Dilithium implementations.
 
 # Add expand_bit method to CT::Mask
 #   Author:    @FAlbertDev
 #   Approvals: (@randombit)
 - pr: 4254  # https://github.com/randombit/botan/pull/4254
   merge_commit: e6d16838e055f4b86c18f2e49d7240ad4a66ec05
-  classification: unspecified
+  classification: relevant
 
 # HSS-LMS with Valgrind
 #   Author:    @FAlbertDev
 #   Approvals: @reneme, (@randombit)
 - pr: 4272  # https://github.com/randombit/botan/pull/4272
   merge_commit: a36c219c7ff63edbf803b5a4540819e05f1f72b5
-  classification: unspecified
+  classification: relevant
+  comment: |
+    Add Valgrind constant time checks to the HSS-LMS
+    implementations.
 
 # CT::Poison: Return input
 #   Author:    @FAlbertDev
 #   Approvals: @reneme, (@randombit)
 - pr: 4260  # https://github.com/randombit/botan/pull/4260
   merge_commit: 5d25f53b4c662be91ee039125c51a74baaa01131
-  classification: unspecified
+  classification: relevant
+  comment: |
+    Add some convenience functions for Valgrind usage.

--- a/docs/audit_report/changes/topics/encoding.yml
+++ b/docs/audit_report/changes/topics/encoding.yml
@@ -1,25 +1,36 @@
 title: Encoding
-
 description: |
-  TODO: Maybe we could merge this with 'chore'
+  Most notably, the encoding and decoding functions for base64 and hex
+  encoding and decoding have been rewritten using a constant time SWAR
+  (SIMD within a register) implementation.
 
 patches:
 # Improve base64 encoding and decoding performance
 #   Author:    @randombit
 - pr: 4271  # https://github.com/randombit/botan/pull/4271
   merge_commit: efad31087c3fba7d86df98b805c381c1826161e3
-  classification: unspecified
+  classification: critical
+  auditer: FAlbertDev
+  comment: |
+    Rewrite the base64 encoding and decoding functions for performance
+    optimization. The new implementation uses a constant time SWAR
+    approach.
 
 # Add SWAR based hex encoding/decoding
 #   Author:    @randombit
 #   Approvals: @reneme
 - pr: 4275  # https://github.com/randombit/botan/pull/4275
   merge_commit: 65db8e32c39d00fbfa5d97859625e0a48e2aa59d
-  classification: unspecified
+  classification: critical
+  comment: |
+    Rewrite the hex encoding and decoding functions for performance
+    optimization. The new implementation uses a constant time SWAR
+    approach. Also, some new convenience functions are added for SWAR and
+    integrated into the new hex and base64 implementation.
 
 # Load/Store for SIMD type wrappers
 #   Author:    @reneme
 #   Approvals: (@randombit)
 - pr: 4288  # https://github.com/randombit/botan/pull/4288
   merge_commit: 5f4c2c3e427fde525377e23cdaeee845d534e757
-  classification: unspecified
+  classification: relevant

--- a/docs/audit_report/changes/topics/fixes.yml
+++ b/docs/audit_report/changes/topics/fixes.yml
@@ -26,67 +26,71 @@ patches:
 #   Author:    @randombit
 - pr: 4248  # https://github.com/randombit/botan/pull/4248
   merge_commit: ddcf530d9485236693647f75a100874bfb8546bf
-  classification: unspecified
+  classification: info
+  auditer: FAlbertDev
 
 # Explicitly enable rdrand intrinsics for processor_rng.
 #   Author:    @solemnwarning
 #   Approvals: (@randombit)
 - pr: 4246  # https://github.com/randombit/botan/pull/4246
   merge_commit: 3e2a7ce142bcbd6c32cad7cb6f38399bc9dcb3a4
-  classification: unspecified
+  classification: info
+  auditer: FAlbertDev
 
 # Fix: Deprecated BigInt::Base Enum Warnings
 #   Author:    @FAlbertDev
 #   Approvals: (@randombit)
 - pr: 4303  # https://github.com/randombit/botan/pull/4303
   merge_commit: 244c0cb35c7efd75bd994bea6749d0fac6245a01
-  classification: unspecified
+  classification: info
 
 # Fix aarch64/armv7/ppc64 feature detection for systems with AT_HWCAP != 16
 #   Author:    @randombit
 - pr: 4315  # https://github.com/randombit/botan/pull/4315
   merge_commit: 56f732fe45ef47b75515e43ec39a240fd63ba09a
-  classification: unspecified
+  classification: info
+  auditer: FAlbertDev
 
 # FIX: X.509 key usage for KEMs
 #   Author:    @reneme
 #   Approvals: (@randombit)
 - pr: 4322  # https://github.com/randombit/botan/pull/4322
   merge_commit: 96a3109904bb43f21112a2402c994ae76da7f031
-  classification: unspecified
+  classification: info
 
 # Fix x86 SM3 CPUID detection
 #   Author: Jack Lloyd
 - commit: 97e03cea85ec344d5e395865fd6590a753881fc0  # https://github.com/randombit/botan/commit/97e03cea85ec344d5e395865fd6590a753881fc0
-  classification: unspecified
+  classification: info
+  auditer: FAlbertDev
 
 # FIX: `ninja tests` fails to build with shared library
 #   Author:    @reneme
 #   Approvals: (@securitykernel)
 - pr: 4336  # https://github.com/randombit/botan/pull/4336
   merge_commit: 89c74e95e68dd1ea754fdad602c5011744c0a8c3
-  classification: unspecified
+  classification: info
 
 # Fix TLS::Context Visibility
 #   Author:    @atreiber94
 #   Approvals: @reneme
 - pr: 4335  # https://github.com/randombit/botan/pull/4335
   merge_commit: 0639e821247e61b186c52fbe315dbb0fa5dd4fa6
-  classification: unspecified
+  classification: info
 
 # Reduce risk of compiler value range propogation in FrodoKEM sampling
 #   Author:    @randombit
 #   Approvals: @reneme
 - pr: 4397  # https://github.com/randombit/botan/pull/4397
   merge_commit: 4ea579a93f03193677a63d2452136599cec66f20
-  classification: unspecified
+  classification: relevant
 
 # Add more value barriers to avoid compiler induced side channels
 #   Author:    @randombit
 #   Approvals: @reneme
 - pr: 4395  # https://github.com/randombit/botan/pull/4395
   merge_commit: b9f712741791bff3dcc2303c3202037555f64f0a
-  classification: unspecified
+  classification: relevant
 
 # Fix an error and some warnings with --disable-asm
 #   Author:    @randombit


### PR DESCRIPTION
This PR covers the Botan 3.6.0 audit for crystals and CT Helpers

Progress: #242