### PR TITLE
Cryptodoc Update: pcurves

### DIFF
--- a/docs/cryptodoc/src/05_03_ecc.rst
+++ b/docs/cryptodoc/src/05_03_ecc.rst
@@ -17,10 +17,14 @@ elliptic curve parameter generation is not implemented. Various standardized
 curves are provided in :srcref:`src/lib/pubkey/ec_group/ec_named.cpp`. All curves
 recommended in [TR-02102-1]_ are included.
 
-Internal elliptic curve structures, including points and scalars, as well as
-operations like scalar multiplication, are implemented across various files
-and classes in :srcref:`src/lib/pubkey/ec_group/`. Optimized implementations
-for numerous named curves are available in :srcref:`src/lib/math/pcurves/`.
+Elliptic curve structures, including points and scalars, as well as operations
+like scalar multiplication, are implemented across various files and classes.
+Currently, there are two distinct implementations for elliptic curve
+mathematics. The first implementation, designed for numerous named curves, is
+located in :srcref:`src/lib/math/pcurves/`. This implementation utilizes
+curve-specific optimized operations to enhance performance. For curves not yet
+supported by the optimized implementation or for custom curves, a generic
+implementation is available in :srcref:`src/lib/pubkey/ec_group/`.
 
 It is possible to import custom elliptic curves at run time. However, it is the
 application developer's responsibility to ensure that such custom curves are

--- a/docs/cryptodoc/src/05_03_ecc.rst
+++ b/docs/cryptodoc/src/05_03_ecc.rst
@@ -13,9 +13,14 @@ curve, a base point of the curve, the order of the base point and the cofactor.
 Theoretically, it is possible to generate a new elliptic curve suitable for
 ECDH. As this process is very costly and comes with many pitfalls, only
 precomputed standardized curves are used in Botan. Thus the feature of
-elliptic curve parameter generation is not implemented. 27 standardized
+elliptic curve parameter generation is not implemented. Various standardized
 curves are provided in :srcref:`src/lib/pubkey/ec_group/ec_named.cpp`. All curves
 recommended in [TR-02102-1]_ are included.
+
+Internal elliptic curve structures, including points and scalars, as well as
+operations like scalar multiplication, are implemented across various files
+and classes in :srcref:`src/lib/pubkey/ec_group/`. Optimized implementations
+for numerous named curves are available in :srcref:`src/lib/math/pcurves/`.
 
 It is possible to import custom elliptic curves at run time. However, it is the
 application developer's responsibility to ensure that such custom curves are

--- a/docs/cryptodoc/src/05_03_ecc.rst
+++ b/docs/cryptodoc/src/05_03_ecc.rst
@@ -20,7 +20,8 @@ recommended in [TR-02102-1]_ are included.
 Elliptic curve structures, including points and scalars, as well as operations
 like scalar multiplication, are implemented across various files and classes.
 Currently, there are two distinct implementations for elliptic curve
-mathematics. The first implementation, designed for numerous named curves, is
+mathematics. The first implementation, designed for several labeled curves
+[#supported_curves]_, is
 located in :srcref:`src/lib/math/pcurves/`. This implementation utilizes
 curve-specific optimized operations to enhance performance. For curves not yet
 supported by the optimized implementation or for custom curves, a generic
@@ -46,6 +47,10 @@ The verification function operates as follows.
    - :math:`G_{x,y}` on :math:`E_{a,b}(\mathbb{F}_p)`: the base point of the curve :math:`E_{a,b}`
    - :math:`n = ord(G_{x,y})`: the order of the base point :math:`G_{x,y}`
    - :math:`h = \#E_{a,b}(\mathbb{F}_p)/n`: the cofactor of the curve
+
+.. [#supported_curves]
+   Botan's :srcref:`src/lib/math/pcurves/` directory contains a subdirectory for
+   each supported curve.
 
 .. admonition:: ``EC_Group::verify_group()``
 


### PR DESCRIPTION
I checked out the current cryptodoc and noticed it doesn't dive into the details of internal elliptic curve operations. I didn't want to get too specific, so I left most of it as is. But for those who want to dig deeper into the internals, I included a source reference to the pcurves module. Hope this suffices.