### PR TITLE
Enable :srcref: in audit report document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,14 @@ jobs:
           AUDIT_REPO_LOCATION: ${{ github.workspace }}/botan
           BASIC_GH_TOKEN: ${{ github.token }}
 
+      - name: Check Source Links
+        working-directory: source/docs/audit_report
+        run: poetry run make SPHINXOPTS="-D src_ref_check_url=True -W --keep-going" html
+        env:
+          AUDIT_CACHE_LOCATION: ${{ github.workspace }}/audit_generator_cache
+          AUDIT_REPO_LOCATION: ${{ github.workspace }}/botan
+          BASIC_GH_TOKEN: ${{ github.token }}
+
       - name: Query the API Rate Limit
         run: ${{ github.workspace }}/source/.github/scripts/query_rate_limit.sh
         if: always()

--- a/docs/audit_report/src/conf.py
+++ b/docs/audit_report/src/conf.py
@@ -39,6 +39,7 @@ rst_prolog = auditinfo.rst_substitutions({
 # ones.
 extensions = [
   'sphinx.ext.todo',
+  'sourceref',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Note that in contrast to the other documents, the URL check is incorporated into the normal document generation job on CI. The cache handling of the audit report job is just too complicated to refactor now.

I need those for the SCA PRs (#236 #237 #238) because these reports are referencing into the upstream code.