### PR TITLE
Validation → Verification

### DIFF
--- a/docs/cryptodoc/src/05_05_xmss.rst
+++ b/docs/cryptodoc/src/05_05_xmss.rst
@@ -320,16 +320,16 @@ Signature Verification
 WOTS+
 ^^^^^
 
-WOTS+ signature validation strictly follows Algorithm 6 in [XMSS]_. It is
+WOTS+ signature verification strictly follows Algorithm 6 in [XMSS]_. It is
 implemented in :srcref:`[src/lib/pubkey/xmss]/xmss_wots.cpp`.
 
-The signature validation process works as follows:
+The signature verification process works as follows:
 
 .. admonition:: ``XMSS_WOTS_PublicKey()`` constructor
 
    **Input:**
 
-   -  ``m``: message to be validated
+   -  ``m``: message to be verified
    -  ``oid``: XMSS WOTS+ parameters (``n``, ``w``, ``len``, ``PRF``), which are chosen
       automatically based on the XMSS parameters from Table
       :ref:`Supported XMSS Signature algorithms <pubkey_key_generation/xmss/table>`, see [XMSS]_
@@ -360,7 +360,7 @@ The signature validation process works as follows:
 XMSS
 ^^^^
 
-XMSS signature validation functionality is implemented in
+XMSS signature verification functionality is implemented in
 :srcref:`[src/lib/pubkey/xmss]/xmss_publickey.cpp` and
 :srcref:`[src/lib/pubkey/xmss]/xmss_verification_operation.cpp`.
 
@@ -368,11 +368,11 @@ The algorithm for signature verification follows methods
 ``XMSS_rootFromSig`` and ``XMSS_verify`` from Algorithms 13 and 14 in
 [XMSS]_. The algorithm works as follows:
 
-.. admonition:: XMSS Signature Validation
+.. admonition:: XMSS Signature Verification
 
    **Input:**
 
-   -  ``m``: message to be validated
+   -  ``m``: message to be verified
    -  ``Sig``: XMSS signature
    -  ``PK``: XMSS public key, ``PK = {root, public_seed}``
 
@@ -428,5 +428,5 @@ Botan's XMSS signing implementation in production applications**. Similarly,
 [SP800-208]_ demands the usage of dedicated hardware for XMSS private key
 operations.
 
-Note that validating XMSS signatures does not depend on this state management
+Note that verifying XMSS signatures does not depend on this state management
 and its usability is therefore *not affected* by this disclaimer.

--- a/docs/cryptodoc/src/05_06_hss_lms.rst
+++ b/docs/cryptodoc/src/05_06_hss_lms.rst
@@ -394,22 +394,22 @@ It works as follows:
 
    - After signature creation, ``idx`` of ``SK`` is increased by one.
 
-.. _pubkey/hss_lms/sig_validation:
+.. _pubkey/hss_lms/sig_verification:
 
-Signature Validation
---------------------
+Signature Verification
+----------------------
 
 Botan's method ``HSS_LMS_Verification_Operation::is_valid_signature`` verifies a
 signature-message pair by implementing the method of Section 6.3. of [RFC8554]_
 (see :srcref:`[src/lib/pubkey/hss_lms]/hss.cpp:343|HSS_LMS_PublicKeyInternal::verify_signature`).
 It does the following:
 
-.. admonition:: HSS Signature Validation
+.. admonition:: HSS Signature Verification
 
    **Input:**
 
-   -  ``m``: message to be validated
-   -  ``sig``: signature to be validated
+   -  ``m``: message to be verified
+   -  ``sig``: signature to be verified
    -  ``PK``: HSS public key, ``PK = {L, lms-pk[0]}``
 
    **Output:**


### PR DESCRIPTION
Mentioned in #235. For the PQC signature algorithms, we wrote _validation_ where we meant _verification_. This PR fixes this issue for HSS/LMS and XMSS. For SLH-DSA and ML-DSA, this is fixed in the respective open PRs.